### PR TITLE
Fix injectAutoEnterXR() in case no display

### DIFF
--- a/examples/outputs/log_performance_drawcall_1024_go_off
+++ b/examples/outputs/log_performance_drawcall_1024_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_drawcall",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 4.187253998827574,
+        "max": 20.84897006087902,
+        "avg": 18.325375023496267,
+        "standard_deviation": 2.67316325201997
+      },
+      "dt": {
+        "min": 42.51999999999862,
+        "max": 274.4400000000023,
+        "avg": 54.89471226021689,
+        "standard_deviation": 17.288353508522345
+      },
+      "cpu": {
+        "min": 48.041905712148036,
+        "max": 95.82866500043232,
+        "avg": 78.23885728269624,
+        "standard_deviation": 8.177689543303817
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 1024,
+        "max": 1024,
+        "avg": 1024,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 990208,
+        "max": 990208,
+        "avg": 990208,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 2970624,
+        "max": 2970624,
+        "avg": 2970624,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 67060.31999999999,
+  "timeToFirstFrame": 1042.7800000000007,
+  "avgFps": 18.176987509683034,
+  "numStutterEvents": 88,
+  "totalRenderTime": 66017.54,
+  "cpuTime": 51233.51999999996,
+  "cpuIdleTime": 14585.240000000038,
+  "cpuIdlePerc": 22.09297710881084,
+  "pageLoadTime": 659.3400000000001,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_drawcall",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 1.9102196752783724,
+        "max": 35.55555555463573,
+        "avg": 32.0773967134471,
+        "standard_deviation": 3.855310419902619
+      },
+      "dt": {
+        "min": 22.200000006705523,
+        "max": 946.8999999953667,
+        "avg": 31.933861551296527,
+        "standard_deviation": 27.684472109974703
+      },
+      "cpu": {
+        "min": 45.28461294712472,
+        "max": 92.55319148318587,
+        "avg": 77.06789350311797,
+        "standard_deviation": 5.5926038751470335
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 1024,
+        "avg": 1023.1466666666671,
+        "standard_deviation": 29.548014409695202
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 990208,
+        "avg": 989382.8266666675,
+        "standard_deviation": 28572.92993417522
+      },
+      "vertices": {
+        "min": 0,
+        "max": 2970624,
+        "avg": 2968148.4800000037,
+        "standard_deviation": 85718.78980252586
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 39904.49999998964,
+  "timeToFirstFrame": 1385.6999999989057,
+  "avgFps": 31.15361849279543,
+  "numStutterEvents": 73,
+  "totalRenderTime": 38518.79999999073,
+  "cpuTime": 29114.30000019027,
+  "cpuIdleTime": 9174.39999981434,
+  "cpuIdlePerc": 23.817979791209872,
+  "pageLoadTime": 1363.6999999871477,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/outputs/log_performance_drawcall_8192
+++ b/examples/outputs/log_performance_drawcall_8192
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_drawcall",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 21.965470279898202,
+        "max": 34.47341853100699,
+        "avg": 31.20790068214209,
+        "standard_deviation": 3.1168572857028924
+      },
+      "dt": {
+        "min": 25.8250000042608,
+        "max": 100.47499999927823,
+        "avg": 32.172627189328544,
+        "standard_deviation": 8.331754219716133
+      },
+      "cpu": {
+        "min": 82.8955901361311,
+        "max": 99.12084397903925,
+        "avg": 95.99249382779801,
+        "standard_deviation": 1.6099348984261441
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 8192,
+        "max": 8192,
+        "avg": 8192,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 7921664,
+        "max": 7921664,
+        "avg": 7921664,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 23764992,
+        "max": 23764992,
+        "avg": 23764992,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 39192.4549999967,
+  "timeToFirstFrame": 508.4249999927124,
+  "avgFps": 31.02055292584243,
+  "numStutterEvents": 41,
+  "totalRenderTime": 38684.030000003986,
+  "cpuTime": 37061.400000107824,
+  "cpuIdleTime": 1513.579999897047,
+  "cpuIdlePerc": 3.9126740411919103,
+  "pageLoadTime": 362.6949999888893,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_drawcall",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 7.662835249042145,
+        "max": 20,
+        "avg": 18.075826810508204,
+        "standard_deviation": 1.306414678369723
+      },
+      "dt": {
+        "min": 10,
+        "max": 360,
+        "avg": 55.650542118432064,
+        "standard_deviation": 11.173981497588176
+      },
+      "cpu": {
+        "min": 0,
+        "max": 100,
+        "avg": 93.77605148930103,
+        "standard_deviation": 9.013868225019213
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 8192,
+        "avg": 8178.346666666663,
+        "standard_deviation": 334.15818582754423
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 7921664,
+        "avg": 7908461.226666662,
+        "standard_deviation": 323130.9656952353
+      },
+      "vertices": {
+        "min": 0,
+        "max": 23764992,
+        "avg": 23725383.679999996,
+        "standard_deviation": 969392.8970857046
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 66971,
+  "timeToFirstFrame": 167,
+  "avgFps": 17.96299622777079,
+  "numStutterEvents": 27,
+  "totalRenderTime": 66804,
+  "cpuTime": 61933,
+  "cpuIdleTime": 4792,
+  "cpuIdlePerc": 7.173223160289803,
+  "pageLoadTime": 151,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_drawcall_raw_8192
+++ b/examples/outputs/log_performance_drawcall_raw_8192
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_drawcall_raw",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 14.063378961495443,
+        "max": 32.90710793369753,
+        "avg": 23.503958266808105,
+        "standard_deviation": 3.584487000476949
+      },
+      "dt": {
+        "min": 10.625000009895302,
+        "max": 134.66999999945983,
+        "avg": 42.747539616347396,
+        "standard_deviation": 17.402487715389277
+      },
+      "cpu": {
+        "min": 72.48018119168104,
+        "max": 99.32751402783404,
+        "avg": 96.81960364486194,
+        "standard_deviation": 2.3279034441421813
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 8192,
+        "max": 8192,
+        "avg": 8192,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 7921664,
+        "max": 7921664,
+        "avg": 7921664,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 23764992,
+        "max": 23764992,
+        "avg": 23764992,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 52063.750000001164,
+  "timeToFirstFrame": 602.4999999935972,
+  "avgFps": 23.318516359393204,
+  "numStutterEvents": 124,
+  "totalRenderTime": 51461.25000000757,
+  "cpuTime": 49887.31999976153,
+  "cpuIdleTime": 1366.980000238982,
+  "cpuIdlePerc": 2.656328791544669,
+  "pageLoadTime": 553.7400000030175,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_drawcall_raw",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 22.727272727272727,
+        "max": 30.97345132743363,
+        "avg": 29.284646467390413,
+        "standard_deviation": 1.2982186974206593
+      },
+      "dt": {
+        "min": 26,
+        "max": 68,
+        "avg": 34.181818181818244,
+        "standard_deviation": 4.295036959372027
+      },
+      "cpu": {
+        "min": 45.588235294117645,
+        "max": 100,
+        "avg": 88.39374152316957,
+        "standard_deviation": 10.891188028576368
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 8192,
+        "max": 8192,
+        "avg": 8192,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 7921664,
+        "max": 7921664,
+        "avg": 7921664,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 23764992,
+        "max": 23764992,
+        "avg": 23764992,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 41427,
+  "timeToFirstFrame": 369,
+  "avgFps": 29.226947245360222,
+  "numStutterEvents": 60,
+  "totalRenderTime": 41058,
+  "cpuTime": 35803,
+  "cpuIdleTime": 5181,
+  "cpuIdlePerc": 12.618734473184276,
+  "pageLoadTime": 298,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_lazy2_10000.json
+++ b/examples/outputs/log_performance_lazy2_10000.json
@@ -1,0 +1,841 @@
+[{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 32.38941328877033,
+        "max": 40.90165424465422,
+        "avg": 37.59010414069924,
+        "standard_deviation": 1.1759433117717264
+      },
+      "dt": {
+        "min": 19.964999999501742,
+        "max": 284.1549999975541,
+        "avg": 26.82659716430243,
+        "standard_deviation": 8.531979307600235
+      },
+      "cpu": {
+        "min": 47.176716932582224,
+        "max": 97.93793793906943,
+        "avg": 94.18411399917338,
+        "standard_deviation": 3.32787692200731
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 32521.950000002107,
+  "timeToFirstFrame": 204.50500000151806,
+  "avgFps": 37.13164824756345,
+  "numStutterEvents": 211,
+  "totalRenderTime": 32317.44500000059,
+  "cpuTime": 30203.635000005306,
+  "cpuIdleTime": 1961.4549999932933,
+  "cpuIdlePerc": 6.069338092764628,
+  "pageLoadTime": 203.15000000118744,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 32.3191283069399,
+        "max": 40.2504472269808,
+        "avg": 37.268516628126285,
+        "standard_deviation": 1.208309138531434
+      },
+      "dt": {
+        "min": 19.61000000301283,
+        "max": 274.5099999992817,
+        "avg": 27.052714762300372,
+        "standard_deviation": 8.220201284919854
+      },
+      "cpu": {
+        "min": 45.889038651157044,
+        "max": 98.09428284799056,
+        "avg": 94.07713793207895,
+        "standard_deviation": 3.5030531848190507
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 32820.26000000042,
+  "timeToFirstFrame": 234.71000000063214,
+  "avgFps": 36.82613919359986,
+  "numStutterEvents": 180,
+  "totalRenderTime": 32585.549999999785,
+  "cpuTime": 30416.450000000623,
+  "cpuIdleTime": 2019.7549999975308,
+  "cpuIdlePerc": 6.198314897239863,
+  "pageLoadTime": 231.9050000005518,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 29.532645878583434,
+        "max": 39.99800009990002,
+        "avg": 36.52510577967797,
+        "standard_deviation": 1.8503554089197205
+      },
+      "dt": {
+        "min": 19.714999998541316,
+        "max": 268.6150000008638,
+        "avg": 27.57697664720467,
+        "standard_deviation": 8.076102016602222
+      },
+      "cpu": {
+        "min": 44.86532770022327,
+        "max": 98.0747126503681,
+        "avg": 94.24612319904816,
+        "standard_deviation": 3.491780991192552
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 33419.33000000063,
+  "timeToFirstFrame": 202.75000000037835,
+  "avgFps": 36.12653680782281,
+  "numStutterEvents": 160,
+  "totalRenderTime": 33216.58000000025,
+  "cpuTime": 31068.53000004776,
+  "cpuIdleTime": 1996.2649999506539,
+  "cpuIdlePerc": 6.009845083240474,
+  "pageLoadTime": 201.83499999984633,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "3",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 30.860795767450846,
+        "max": 41.236168701791065,
+        "avg": 37.350451041129375,
+        "standard_deviation": 1.670584440667318
+      },
+      "dt": {
+        "min": 19.860000000335276,
+        "max": 267.49000000199885,
+        "avg": 27.00248123436117,
+        "standard_deviation": 8.16746522449527
+      },
+      "cpu": {
+        "min": 45.280197390140394,
+        "max": 97.77699983007454,
+        "avg": 94.19765997263525,
+        "standard_deviation": 3.5849682582072133
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 32734.850000000733,
+  "timeToFirstFrame": 202.51000000280328,
+  "avgFps": 36.88637214538137,
+  "numStutterEvents": 232,
+  "totalRenderTime": 32532.33999999793,
+  "cpuTime": 30407.969999978377,
+  "cpuIdleTime": 1968.0050000206393,
+  "cpuIdlePerc": 6.049380401227715,
+  "pageLoadTime": 201.57000000108383,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "4",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 29.39591396813651,
+        "max": 41.21728378083204,
+        "avg": 36.43558890636242,
+        "standard_deviation": 1.410275211402355
+      },
+      "dt": {
+        "min": 20.95499999995809,
+        "max": 268.38000000134343,
+        "avg": 27.64604253544781,
+        "standard_deviation": 7.954181649327368
+      },
+      "cpu": {
+        "min": 43.852000893710446,
+        "max": 98.12054976215245,
+        "avg": 93.97815146780462,
+        "standard_deviation": 3.7032726707808874
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 33517.44999999937,
+  "timeToFirstFrame": 214.85000000029686,
+  "avgFps": 36.03322263126703,
+  "numStutterEvents": 126,
+  "totalRenderTime": 33302.599999999074,
+  "cpuTime": 31061.45000003744,
+  "cpuIdleTime": 2086.154999964492,
+  "cpuIdlePerc": 6.264240629754284,
+  "pageLoadTime": 213.96499999900698,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "5",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 7.2727272727272725,
+        "max": 27.272727272727273,
+        "avg": 24.070881950472288,
+        "standard_deviation": 1.8065867372900335
+      },
+      "dt": {
+        "min": 18,
+        "max": 393,
+        "avg": 41.74395329441196,
+        "standard_deviation": 12.167732169126824
+      },
+      "cpu": {
+        "min": 11.11111111111111,
+        "max": 100,
+        "avg": 90.77572630229325,
+        "standard_deviation": 11.927209193143765
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4325.778333333322,
+        "standard_deviation": 176.74651113168338
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4183027.648333334,
+        "standard_deviation": 170913.87626433783
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12549082.94500001,
+        "standard_deviation": 512741.62879301305
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 50480,
+  "timeToFirstFrame": 117,
+  "avgFps": 23.827015864821398,
+  "numStutterEvents": 113,
+  "totalRenderTime": 50363,
+  "cpuTime": 44527,
+  "cpuIdleTime": 5524,
+  "cpuIdlePerc": 10.96836963643945,
+  "pageLoadTime": 113,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "6",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 7.604562737642586,
+        "max": 26.548672566371682,
+        "avg": 23.98307673940168,
+        "standard_deviation": 1.745772305962861
+      },
+      "dt": {
+        "min": 35,
+        "max": 350,
+        "avg": 41.922435362802375,
+        "standard_deviation": 11.14989187457122
+      },
+      "cpu": {
+        "min": 43.142857142857146,
+        "max": 100,
+        "avg": 90.76338557493989,
+        "standard_deviation": 11.597250486310001
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 50702,
+  "timeToFirstFrame": 118,
+  "avgFps": 23.72291633718172,
+  "numStutterEvents": 88,
+  "totalRenderTime": 50584,
+  "cpuTime": 44727,
+  "cpuIdleTime": 5538,
+  "cpuIdlePerc": 10.948125889609363,
+  "pageLoadTime": 115,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "7",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 13.574660633484163,
+        "max": 26.905829596412556,
+        "avg": 24.461775558566476,
+        "standard_deviation": 1.3707585756593936
+      },
+      "dt": {
+        "min": 34,
+        "max": 104,
+        "avg": 40.920767306088486,
+        "standard_deviation": 6.552760968374777
+      },
+      "cpu": {
+        "min": 61.53846153846154,
+        "max": 100,
+        "avg": 91.27369272849396,
+        "standard_deviation": 11.261876781472578
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 49844,
+  "timeToFirstFrame": 465,
+  "avgFps": 24.301828712610625,
+  "numStutterEvents": 111,
+  "totalRenderTime": 49379,
+  "cpuTime": 44056,
+  "cpuIdleTime": 5008,
+  "cpuIdlePerc": 10.1419631827295,
+  "pageLoadTime": 309,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "8",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 6.644518272425249,
+        "max": 26.905829596412556,
+        "avg": 23.942788112786435,
+        "standard_deviation": 1.9159644720036375
+      },
+      "dt": {
+        "min": 35,
+        "max": 384,
+        "avg": 42.01834862385323,
+        "standard_deviation": 12.111505717740274
+      },
+      "cpu": {
+        "min": 45.572916666666664,
+        "max": 100,
+        "avg": 90.72582946903746,
+        "standard_deviation": 11.630903409941059
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 50847,
+  "timeToFirstFrame": 140,
+  "avgFps": 23.665371644940542,
+  "numStutterEvents": 122,
+  "totalRenderTime": 50707,
+  "cpuTime": 44796,
+  "cpuIdleTime": 5584,
+  "cpuIdlePerc": 11.012286272112332,
+  "pageLoadTime": 121,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "9",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy2",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 4.761904761904762,
+        "max": 28.037383177570092,
+        "avg": 24.05580128914479,
+        "standard_deviation": 1.928095472451749
+      },
+      "dt": {
+        "min": 35,
+        "max": 394,
+        "avg": 41.744787322768985,
+        "standard_deviation": 12.191955978955978
+      },
+      "cpu": {
+        "min": 46.192893401015226,
+        "max": 100,
+        "avg": 90.75922161034235,
+        "standard_deviation": 11.630045084693391
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 50516,
+  "timeToFirstFrame": 152,
+  "avgFps": 23.82654276864427,
+  "numStutterEvents": 108,
+  "totalRenderTime": 50364,
+  "cpuTime": 44497,
+  "cpuIdleTime": 5555,
+  "cpuIdlePerc": 11.029703756651577,
+  "pageLoadTime": 133,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "10",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_lazy_10000_3.json
+++ b/examples/outputs/log_performance_lazy_10000_3.json
@@ -1,0 +1,841 @@
+[{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 13.961605584309412,
+        "max": 41.917004337067425,
+        "avg": 38.64756934247818,
+        "standard_deviation": 2.608028312523831
+      },
+      "dt": {
+        "min": 18.619999988004565,
+        "max": 310.62000000383705,
+        "avg": 26.035542118466342,
+        "standard_deviation": 9.478450405972358
+      },
+      "cpu": {
+        "min": 41.54272099964799,
+        "max": 97.8842374695787,
+        "avg": 93.67687424116531,
+        "standard_deviation": 4.102475127374277
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 31795.43499997817,
+  "timeToFirstFrame": 323.450000025332,
+  "avgFps": 38.1291488287694,
+  "numStutterEvents": 291,
+  "totalRenderTime": 31471.984999952838,
+  "cpuTime": 29128.03999998141,
+  "cpuIdleTime": 2088.575000059791,
+  "cpuIdlePerc": 6.63629891811057,
+  "pageLoadTime": 322.04499997897074,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 18.10610175690861,
+        "max": 48.85675199730689,
+        "avg": 40.09832985660095,
+        "standard_deviation": 2.612954317703679
+      },
+      "dt": {
+        "min": 17.46500004082918,
+        "max": 329.5799999614246,
+        "avg": 25.11622185153374,
+        "standard_deviation": 9.942447532916445
+      },
+      "cpu": {
+        "min": 36.26281934079291,
+        "max": 97.86114423471635,
+        "avg": 93.73045823792683,
+        "standard_deviation": 4.010590619373997
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 30612.335000012536,
+  "timeToFirstFrame": 278.5050000529736,
+  "avgFps": 39.55979182324157,
+  "numStutterEvents": 305,
+  "totalRenderTime": 30333.829999959562,
+  "cpuTime": 28077.860001067165,
+  "cpuIdleTime": 2036.489998921752,
+  "cpuIdlePerc": 6.713593367288163,
+  "pageLoadTime": 277.6350000058301,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 29.683027663816734,
+        "max": 41.915052163095424,
+        "avg": 39.18968268979842,
+        "standard_deviation": 1.5687790677827171
+      },
+      "dt": {
+        "min": 18.29500001622364,
+        "max": 282.26499998709187,
+        "avg": 25.728152627197236,
+        "standard_deviation": 8.789063543928448
+      },
+      "cpu": {
+        "min": 39.72862380671679,
+        "max": 97.46222172403907,
+        "avg": 93.84370845861804,
+        "standard_deviation": 3.915186176149736
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 31260.725000000093,
+  "timeToFirstFrame": 225.91499995905906,
+  "avgFps": 38.66625895239614,
+  "numStutterEvents": 311,
+  "totalRenderTime": 31034.810000041034,
+  "cpuTime": 28842.37500000745,
+  "cpuIdleTime": 2005.6800000020303,
+  "cpuIdlePerc": 6.462678521310034,
+  "pageLoadTime": 224.99999997671694,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "3",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 14.456786255270686,
+        "max": 48.64286408972665,
+        "avg": 39.60756168211641,
+        "standard_deviation": 2.639604856275418
+      },
+      "dt": {
+        "min": 17.770000034943223,
+        "max": 290.1699999929406,
+        "avg": 25.374182652236577,
+        "standard_deviation": 8.895145933767981
+      },
+      "cpu": {
+        "min": 44.870248460942214,
+        "max": 98.0796158563588,
+        "avg": 93.58689763454397,
+        "standard_deviation": 4.04251132745749
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 30851.619999972172,
+  "timeToFirstFrame": 252.22500000381842,
+  "avgFps": 39.21646163269702,
+  "numStutterEvents": 297,
+  "totalRenderTime": 30599.394999968354,
+  "cpuTime": 28370.585000084247,
+  "cpuIdleTime": 2053.059999947436,
+  "cpuIdlePerc": 6.709479059796965,
+  "pageLoadTime": 251.32499996107072,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "4",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 18.503955217963412,
+        "max": 49.46209967004981,
+        "avg": 40.347842571168464,
+        "standard_deviation": 2.528460486213591
+      },
+      "dt": {
+        "min": 17.389999993611127,
+        "max": 283.1650000298396,
+        "avg": 24.917956630536597,
+        "standard_deviation": 8.789319435218898
+      },
+      "cpu": {
+        "min": 40.299825187407876,
+        "max": 97.75032645951075,
+        "avg": 93.80744539069691,
+        "standard_deviation": 3.816501653471132
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 4333,
+        "avg": 4329.38916666666,
+        "standard_deviation": 125.03080706758752
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 4190011,
+        "avg": 4186519.324166666,
+        "standard_deviation": 120904.79043435684
+      },
+      "vertices": {
+        "min": 0,
+        "max": 12570033,
+        "avg": 12559557.972500008,
+        "standard_deviation": 362714.37130307016
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 30321.075000043493,
+  "timeToFirstFrame": 249.42500004544854,
+  "avgFps": 39.90469428847695,
+  "numStutterEvents": 309,
+  "totalRenderTime": 30071.649999998044,
+  "cpuTime": 27922.58999904152,
+  "cpuIdleTime": 1954.0400009718724,
+  "cpuIdlePerc": 6.497947405519815,
+  "pageLoadTime": 248.38000000454485,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "5",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 15.723270440251572,
+        "max": 29.12621359223301,
+        "avg": 26.23640035596659,
+        "standard_deviation": 2.044881731309336
+      },
+      "dt": {
+        "min": 31,
+        "max": 187,
+        "avg": 38.21601334445375,
+        "standard_deviation": 7.435070769733664
+      },
+      "cpu": {
+        "min": 20.855614973262032,
+        "max": 100,
+        "avg": 91.13785164531502,
+        "standard_deviation": 11.265579860487337
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 46715,
+  "timeToFirstFrame": 579,
+  "avgFps": 26.010057222125887,
+  "numStutterEvents": 112,
+  "totalRenderTime": 46136,
+  "cpuTime": 40967,
+  "cpuIdleTime": 4854,
+  "cpuIdlePerc": 10.521068146349922,
+  "pageLoadTime": 368,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "6",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 17.24137931034483,
+        "max": 28.846153846153847,
+        "avg": 25.289189307039265,
+        "standard_deviation": 1.7067372600699582
+      },
+      "dt": {
+        "min": 33,
+        "max": 78,
+        "avg": 39.53461217681405,
+        "standard_deviation": 6.062250990194036
+      },
+      "cpu": {
+        "min": 58.18181818181818,
+        "max": 100,
+        "avg": 91.8791002789711,
+        "standard_deviation": 10.824382601484924
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 48252,
+  "timeToFirstFrame": 534,
+  "avgFps": 25.147742990066643,
+  "numStutterEvents": 107,
+  "totalRenderTime": 47718,
+  "cpuTime": 42874,
+  "cpuIdleTime": 4528,
+  "cpuIdlePerc": 9.489081688251813,
+  "pageLoadTime": 324,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "7",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 17.167381974248926,
+        "max": 28.985507246376812,
+        "avg": 25.853423577304863,
+        "standard_deviation": 1.4529296656070236
+      },
+      "dt": {
+        "min": 32,
+        "max": 72,
+        "avg": 38.699749791492884,
+        "standard_deviation": 5.611253283086914
+      },
+      "cpu": {
+        "min": 59.183673469387756,
+        "max": 100,
+        "avg": 92.25536664907058,
+        "standard_deviation": 10.720177373347815
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 47258,
+  "timeToFirstFrame": 529,
+  "avgFps": 25.679984592009244,
+  "numStutterEvents": 105,
+  "totalRenderTime": 46729,
+  "cpuTime": 42178,
+  "cpuIdleTime": 4223,
+  "cpuIdlePerc": 9.037214577671254,
+  "pageLoadTime": 312,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "8",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 16.877637130801688,
+        "max": 28.846153846153847,
+        "avg": 25.651494009614787,
+        "standard_deviation": 1.999351302528846
+      },
+      "dt": {
+        "min": 32,
+        "max": 113,
+        "avg": 39.03169307756466,
+        "standard_deviation": 6.589778754954006
+      },
+      "cpu": {
+        "min": 28.31858407079646,
+        "max": 100,
+        "avg": 91.61306756612314,
+        "standard_deviation": 11.111534288802016
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 47666,
+  "timeToFirstFrame": 558,
+  "avgFps": 25.473380317568143,
+  "numStutterEvents": 105,
+  "totalRenderTime": 47108,
+  "cpuTime": 42151,
+  "cpuIdleTime": 4648,
+  "cpuIdlePerc": 9.866689309671393,
+  "pageLoadTime": 351,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "9",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_lazy",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 16.260162601626018,
+        "max": 28.571428571428573,
+        "avg": 25.222184235692314,
+        "standard_deviation": 1.6938566941987574
+      },
+      "dt": {
+        "min": 33,
+        "max": 93,
+        "avg": 39.6613844870726,
+        "standard_deviation": 6.287026907920023
+      },
+      "cpu": {
+        "min": 60,
+        "max": 100,
+        "avg": 92.05190696679121,
+        "standard_deviation": 10.593058440486386
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 4333,
+        "max": 4333,
+        "avg": 4333,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 4190011,
+        "max": 4190011,
+        "avg": 4190011,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 12570033,
+        "max": 12570033,
+        "avg": 12570033,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 48557,
+  "timeToFirstFrame": 676,
+  "avgFps": 25.062133205237984,
+  "numStutterEvents": 116,
+  "totalRenderTime": 47881,
+  "cpuTime": 43094,
+  "cpuIdleTime": 4460,
+  "cpuIdlePerc": 9.314759507946786,
+  "pageLoadTime": 479,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "10",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_matrices_16384_go_off
+++ b/examples/outputs/log_performance_matrices_16384_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_matrices",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 9.203865623561926,
+        "max": 20.62025734081165,
+        "avg": 19.183137728817858,
+        "standard_deviation": 1.3666797419634635
+      },
+      "dt": {
+        "min": 44.5,
+        "max": 262.3200000000006,
+        "avg": 52.22792326939114,
+        "standard_deviation": 9.202406995973968
+      },
+      "cpu": {
+        "min": 41.10247026532493,
+        "max": 96.0694050991483,
+        "avg": 88.05818793594568,
+        "standard_deviation": 4.598406951162764
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 64926.62000000001,
+  "timeToFirstFrame": 2209.5,
+  "avgFps": 19.133531641759056,
+  "numStutterEvents": 7,
+  "totalRenderTime": 62717.12000000001,
+  "cpuTime": 54852.80000000004,
+  "cpuIdleTime": 7768.479999999959,
+  "cpuIdlePerc": 12.3865381573643,
+  "pageLoadTime": 1933.8200000000006,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_matrices",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 3.5137034434411603,
+        "max": 31.02836879360893,
+        "avg": 28.759146259618788,
+        "standard_deviation": 2.5608071956685716
+      },
+      "dt": {
+        "min": 29.29999999469146,
+        "max": 253.19999999192078,
+        "avg": 34.903419516261025,
+        "standard_deviation": 8.450017691200607
+      },
+      "cpu": {
+        "min": 22.44265344122981,
+        "max": 93.73297004626315,
+        "avg": 83.15004882949583,
+        "standard_deviation": 4.332097656649995
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 45294.40000001341,
+  "timeToFirstFrame": 3286.3000000070315,
+  "avgFps": 28.56591942981991,
+  "numStutterEvents": 10,
+  "totalRenderTime": 42008.10000000638,
+  "cpuTime": 34576.69999996142,
+  "cpuIdleTime": 7272.500000035507,
+  "cpuIdlePerc": 17.312137421198297,
+  "pageLoadTime": 3096.8000000139,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/outputs/log_performance_matrices_raw_262144
+++ b/examples/outputs/log_performance_matrices_raw_262144
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_matrices_raw",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 24.81143310898321,
+        "max": 30.126315336433706,
+        "avg": 29.01082937926647,
+        "standard_deviation": 0.8262544515244088
+      },
+      "dt": {
+        "min": 30.384999998204876,
+        "max": 105.2750000017113,
+        "avg": 34.56290658882009,
+        "standard_deviation": 2.8936823632014326
+      },
+      "cpu": {
+        "min": 44.0655426287372,
+        "max": 99.62317474506462,
+        "avg": 97.70115406048419,
+        "standard_deviation": 1.7628231430691206
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 42617.10000000312,
+  "timeToFirstFrame": 1174.9449999988428,
+  "avgFps": 28.956023160472135,
+  "numStutterEvents": 4,
+  "totalRenderTime": 41442.15500000428,
+  "cpuTime": 40441.91000018327,
+  "cpuIdleTime": 999.0149998120614,
+  "cpuIdlePerc": 2.4106251226847597,
+  "pageLoadTime": 1129.25499999983,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_matrices_raw",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 4.587155963302752,
+        "max": 13.636363636363637,
+        "avg": 12.808863558761432,
+        "standard_deviation": 0.6279012003632763
+      },
+      "dt": {
+        "min": 72,
+        "max": 214,
+        "avg": 78.22768974145121,
+        "standard_deviation": 6.188371935048174
+      },
+      "cpu": {
+        "min": 34.11214953271028,
+        "max": 100,
+        "avg": 98.32567928735753,
+        "standard_deviation": 4.241164301845894
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 95402,
+  "timeToFirstFrame": 1605,
+  "avgFps": 12.79358614881073,
+  "numStutterEvents": 1,
+  "totalRenderTime": 93797,
+  "cpuTime": 91971,
+  "cpuIdleTime": 1824,
+  "cpuIdlePerc": 1.944625094619231,
+  "pageLoadTime": 1512,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_matrices_raw_float32_262144
+++ b/examples/outputs/log_performance_matrices_raw_float32_262144
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_matrices_raw_float32",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 17.336280500796857,
+        "max": 23.08082906310038,
+        "avg": 22.09086904696876,
+        "standard_deviation": 0.9134779963107715
+      },
+      "dt": {
+        "min": 41.43500000645872,
+        "max": 120.55500000133179,
+        "avg": 45.34962051709483,
+        "standard_deviation": 4.050392906341642
+      },
+      "cpu": {
+        "min": 49.67027497826025,
+        "max": 99.57177814367608,
+        "avg": 98.18840270333575,
+        "standard_deviation": 2.254605903152981
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 55656.074999998964,
+  "timeToFirstFrame": 1280.6599999967148,
+  "avgFps": 22.06879708412249,
+  "numStutterEvents": 2,
+  "totalRenderTime": 54375.41500000225,
+  "cpuTime": 53304.44000010175,
+  "cpuIdleTime": 1069.7549998949398,
+  "cpuIdlePerc": 1.967350501867242,
+  "pageLoadTime": 1225.9049999993294,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_matrices_raw_float32",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 8.928571428571429,
+        "max": 15.151515151515152,
+        "avg": 14.507149592311764,
+        "standard_deviation": 0.5061781349210352
+      },
+      "dt": {
+        "min": 63,
+        "max": 199,
+        "avg": 69.00166805671408,
+        "standard_deviation": 5.218974544804922
+      },
+      "cpu": {
+        "min": 34.67336683417086,
+        "max": 100,
+        "avg": 98.73387684700043,
+        "standard_deviation": 3.3517318649267405
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 84187,
+  "timeToFirstFrame": 1452,
+  "avgFps": 14.504139723212667,
+  "numStutterEvents": 2,
+  "totalRenderTime": 82735,
+  "cpuTime": 81519,
+  "cpuIdleTime": 1214,
+  "cpuIdlePerc": 1.4673354686650149,
+  "pageLoadTime": 1379,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_matrices_raw_float64_262144
+++ b/examples/outputs/log_performance_matrices_raw_float64_262144
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_matrices_raw_float64",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 18.527095877474416,
+        "max": 24.907840988315396,
+        "avg": 23.686587303134377,
+        "standard_deviation": 0.9478402805572381
+      },
+      "dt": {
+        "min": 38.11499999574153,
+        "max": 104.67000000062399,
+        "avg": 42.327614678897156,
+        "standard_deviation": 3.8675840417238487
+      },
+      "cpu": {
+        "min": 56.4010700277547,
+        "max": 99.65898522751024,
+        "avg": 98.25081038369841,
+        "standard_deviation": 2.0050912900714932
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 52606.41499999474,
+  "timeToFirstFrame": 1854.3549999958486,
+  "avgFps": 23.644360445665185,
+  "numStutterEvents": 2,
+  "totalRenderTime": 50752.05999999889,
+  "cpuTime": 49794.93000004004,
+  "cpuIdleTime": 955.8799999576877,
+  "cpuIdlePerc": 1.883430938483499,
+  "pageLoadTime": 1796.26499999722,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Chrome",
+    "code": "chrome",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+},{
+  "test_id": "performance_matrices_raw_float64",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 6.993006993006993,
+        "max": 14.851485148514852,
+        "avg": 14.28041536359221,
+        "standard_deviation": 0.5697015451720938
+      },
+      "dt": {
+        "min": 65,
+        "max": 217,
+        "avg": 70.15095913261061,
+        "standard_deviation": 5.49179966408614
+      },
+      "cpu": {
+        "min": 32.71889400921659,
+        "max": 100,
+        "avg": 98.8001633423472,
+        "standard_deviation": 3.208121277287086
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 85753,
+  "timeToFirstFrame": 1640,
+  "avgFps": 14.266522416273347,
+  "numStutterEvents": 2,
+  "totalRenderTime": 84113,
+  "cpuTime": 82936,
+  "cpuIdleTime": 1175,
+  "cpuIdlePerc": 1.396930319926765,
+  "pageLoadTime": 1562,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "FirefoxNightly",
+    "code": "firefoxnightly",
+    "versionCode": "",
+    "versionName": ""
+  },
+  "device": {
+    "name": "PC",
+    "deviceProduct": "localdevice",
+    "serial": ""
+  }
+}]

--- a/examples/outputs/log_performance_practical_4096_go_off
+++ b/examples/outputs/log_performance_practical_4096_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_practical",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 5.57786702365015,
+        "max": 22.236057991639186,
+        "avg": 19.07417944472469,
+        "standard_deviation": 1.8179045430022187
+      },
+      "dt": {
+        "min": 38.960000000000036,
+        "max": 238.26000000000022,
+        "avg": 52.695846538782234,
+        "standard_deviation": 12.00728185079118
+      },
+      "cpu": {
+        "min": 30.217669654288073,
+        "max": 91.807157645666,
+        "avg": 76.91143570292486,
+        "standard_deviation": 9.445045544259484
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 349,
+        "max": 350,
+        "avg": 349.00083333333333,
+        "standard_deviation": 0.028855482821962465
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 337483,
+        "max": 338450,
+        "avg": 337483.80583333294,
+        "standard_deviation": 27.903251888835815
+      },
+      "vertices": {
+        "min": 1012449,
+        "max": 1015350,
+        "avg": 1012451.4174999996,
+        "standard_deviation": 83.70975566654214
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 65143.92,
+  "timeToFirstFrame": 1330.04,
+  "avgFps": 18.804686378574694,
+  "numStutterEvents": 156,
+  "totalRenderTime": 63813.88,
+  "cpuTime": 47942.17999999999,
+  "cpuIdleTime": 15240.14000000001,
+  "cpuIdlePerc": 23.882171088797627,
+  "pageLoadTime": 979.5799999999999,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_practical",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 1.9747235387108462,
+        "max": 31.48897885825081,
+        "avg": 28.292884164689266,
+        "standard_deviation": 2.8513871503066426
+      },
+      "dt": {
+        "min": 29.099999999743886,
+        "max": 1397.1000000165077,
+        "avg": 36.370475396165524,
+        "standard_deviation": 39.717674576796625
+      },
+      "cpu": {
+        "min": 32.996922196320774,
+        "max": 94.4761904638362,
+        "avg": 82.71916803600978,
+        "standard_deviation": 3.971034100176895
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 349,
+        "avg": 348.709166666667,
+        "standard_deviation": 10.07056350486682
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 337483,
+        "avg": 337201.76416666625,
+        "standard_deviation": 9738.23490920623
+      },
+      "vertices": {
+        "min": 0,
+        "max": 1012449,
+        "avg": 1011605.2924999997,
+        "standard_deviation": 29214.70472761865
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 45153.20000000065,
+  "timeToFirstFrame": 1034.8999999987427,
+  "avgFps": 27.199597445956623,
+  "numStutterEvents": 13,
+  "totalRenderTime": 44118.30000000191,
+  "cpuTime": 35332.4999998149,
+  "cpuIdleTime": 8275.700000187499,
+  "cpuIdlePerc": 18.757975715716924,
+  "pageLoadTime": 1010.8999999938533,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/outputs/log_performance_project_16384_go_off
+++ b/examples/outputs/log_performance_project_16384_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_project",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 14.1183114499506,
+        "max": 24.495394865764922,
+        "avg": 21.995854648639416,
+        "standard_deviation": 1.770609644433757
+      },
+      "dt": {
+        "min": 35.44000000000051,
+        "max": 136.77999999999975,
+        "avg": 45.68520433694745,
+        "standard_deviation": 8.412131967639443
+      },
+      "cpu": {
+        "min": 37.9109446525179,
+        "max": 91.8277680140611,
+        "avg": 75.92488329981514,
+        "standard_deviation": 9.441724635157701
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 57687.92,
+  "timeToFirstFrame": 2776.9000000000005,
+  "avgFps": 21.853536867463035,
+  "numStutterEvents": 156,
+  "totalRenderTime": 54911.02,
+  "cpuTime": 40891.98000000007,
+  "cpuIdleTime": 13884.579999999929,
+  "cpuIdlePerc": 25.285598409936533,
+  "pageLoadTime": 2647.6000000000004,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_project",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 2.6178010472352993,
+        "max": 34.91924923662406,
+        "avg": 32.38394852687958,
+        "standard_deviation": 3.2801832082680837
+      },
+      "dt": {
+        "min": 24.999999994179234,
+        "max": 2478.9999999920838,
+        "avg": 32.98356964136035,
+        "standard_deviation": 71.13692505999855
+      },
+      "cpu": {
+        "min": 6.308995562447444,
+        "max": 91.80327870640232,
+        "avg": 79.02421208664786,
+        "standard_deviation": 5.265456205602938
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 41324.20000000275,
+  "timeToFirstFrame": 1594.9999999866122,
+  "avgFps": 30.204484359098917,
+  "numStutterEvents": 15,
+  "totalRenderTime": 39729.200000016135,
+  "cpuTime": 29220.899999709218,
+  "cpuIdleTime": 10326.400000281865,
+  "cpuIdlePerc": 25.991965607859385,
+  "pageLoadTime": 1566.8000000005122,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/outputs/log_performance_raycast_2048_go_off
+++ b/examples/outputs/log_performance_raycast_2048_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_raycast",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 5.1305730850136,
+        "max": 41.42883446878997,
+        "avg": 35.13203289260058,
+        "standard_deviation": 7.57890344333323
+      },
+      "dt": {
+        "min": 18.840000000000146,
+        "max": 254.03999999999996,
+        "avg": 28.92323603002502,
+        "standard_deviation": 15.647941481144853
+      },
+      "cpu": {
+        "min": 41.411042944788996,
+        "max": 96.46253962956803,
+        "avg": 75.9157693141635,
+        "standard_deviation": 6.547878530257863
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 149,
+        "max": 149,
+        "avg": 149,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 3,
+        "max": 3,
+        "avg": 3,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 1828,
+        "max": 1828,
+        "avg": 1828,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 5748,
+        "max": 5748,
+        "avg": 5748,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 36346.62,
+  "timeToFirstFrame": 1547.3400000000001,
+  "avgFps": 34.48347207183597,
+  "numStutterEvents": 59,
+  "totalRenderTime": 34799.28,
+  "cpuTime": 26400.040000000103,
+  "cpuIdleTime": 8278.919999999896,
+  "cpuIdlePerc": 23.790492217080057,
+  "pageLoadTime": 966.3199999999997,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_raycast",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 6.476683938152482,
+        "max": 39.64321109816892,
+        "avg": 33.16962194629446,
+        "standard_deviation": 4.5665310212698715
+      },
+      "dt": {
+        "min": 20.29999998921994,
+        "max": 210.09999999660067,
+        "avg": 30.289241034195612,
+        "standard_deviation": 10.128978535722986
+      },
+      "cpu": {
+        "min": 37.931034470399254,
+        "max": 90.54878048280023,
+        "avg": 65.27310141782463,
+        "standard_deviation": 7.515604529186885
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 149,
+        "max": 149,
+        "avg": 149,
+        "standard_deviation": 0
+      },
+      "useProgramCalls": {
+        "min": 3,
+        "max": 3,
+        "avg": 3,
+        "standard_deviation": 0
+      },
+      "faces": {
+        "min": 1828,
+        "max": 1828,
+        "avg": 1828,
+        "standard_deviation": 0
+      },
+      "vertices": {
+        "min": 5748,
+        "max": 5748,
+        "avg": 5748,
+        "standard_deviation": 0
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 39747.099999993225,
+  "timeToFirstFrame": 3211.9999999995343,
+  "avgFps": 32.845127014848934,
+  "numStutterEvents": 144,
+  "totalRenderTime": 36535.09999999369,
+  "cpuTime": 23579.700000263983,
+  "cpuIdleTime": 12737.099999736529,
+  "cpuIdlePerc": 34.862638941014886,
+  "pageLoadTime": 2380.8999999891967,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/outputs/log_performance_webgl_1024_go_off
+++ b/examples/outputs/log_performance_webgl_1024_go_off
@@ -1,0 +1,169 @@
+[{
+  "test_id": "performance_webgl",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 0.9716473308847818,
+        "max": 9.550186228631539,
+        "avg": 6.474851603180839,
+        "standard_deviation": 1.31832905734539
+      },
+      "dt": {
+        "min": 96.87999999999738,
+        "max": 1953.38,
+        "avg": 158.2001167639699,
+        "standard_deviation": 65.09010571921428
+      },
+      "cpu": {
+        "min": 50.60459306432952,
+        "max": 98.20930821859733,
+        "avg": 88.51153963316774,
+        "standard_deviation": 5.998223263691609
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 1024,
+        "avg": 1023.1466666666671,
+        "standard_deviation": 29.548014409695202
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 990208,
+        "avg": 989382.8266666675,
+        "standard_deviation": 28572.92993417522
+      },
+      "vertices": {
+        "min": 0,
+        "max": 2970624,
+        "avg": 2968148.4800000037,
+        "standard_deviation": 85718.78980252586
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 190241.80000000002,
+  "timeToFirstFrame": 363.59999999999945,
+  "avgFps": 6.319840824275772,
+  "numStutterEvents": 172,
+  "totalRenderTime": 189878.2,
+  "cpuTime": 166975.2199999997,
+  "cpuIdleTime": 22706.720000000285,
+  "cpuIdlePerc": 11.958571336783413,
+  "pageLoadTime": 354.97999999999956,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "1",
+  "browser": {
+    "name": "Firefox Reality",
+    "code": "fxr",
+    "versionCode": "130091627",
+    "versionName": "1.1.2"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+},{
+  "test_id": "performance_webgl",
+  "stats": {
+    "perf": {
+      "fps": {
+        "min": 0.48690232739449385,
+        "max": 21.276595745945663,
+        "avg": 17.90608249679512,
+        "standard_deviation": 2.151983142488775
+      },
+      "dt": {
+        "min": 40.69999999774154,
+        "max": 2985.5999999999767,
+        "avg": 58.393661384495516,
+        "standard_deviation": 85.6163374648102
+      },
+      "cpu": {
+        "min": 51.47928993586075,
+        "max": 94.73684211014923,
+        "avg": 80.6695458242066,
+        "standard_deviation": 5.515050689622222
+      }
+    },
+    "webgl": {
+      "drawCalls": {
+        "min": 0,
+        "max": 1024,
+        "avg": 1023.1466666666671,
+        "standard_deviation": 29.548014409695202
+      },
+      "useProgramCalls": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.0008333333333333356,
+        "standard_deviation": 0.02885548282196799
+      },
+      "faces": {
+        "min": 0,
+        "max": 990208,
+        "avg": 989382.8266666675,
+        "standard_deviation": 28572.92993417522
+      },
+      "vertices": {
+        "min": 0,
+        "max": 2970624,
+        "avg": 2968148.4800000037,
+        "standard_deviation": 85718.78980252586
+      },
+      "bindTextures": {
+        "min": 0,
+        "max": 0,
+        "avg": 0,
+        "standard_deviation": 0
+      }
+    }
+  },
+  "numFrames": 1200,
+  "totalTime": 71615.99999999453,
+  "timeToFirstFrame": 1307.7999999950407,
+  "avgFps": 17.067710451981544,
+  "numStutterEvents": 97,
+  "totalRenderTime": 70308.19999999949,
+  "cpuTime": 55673.09999989811,
+  "cpuIdleTime": 14340.900000112015,
+  "cpuIdlePerc": 20.397194068561163,
+  "pageLoadTime": 1278.9000000047963,
+  "result": "pass",
+  "logs": {
+    "errors": [],
+    "warnings": [],
+    "catchErrors": []
+  },
+  "testUUID": "2",
+  "browser": {
+    "name": "Oculus Browser",
+    "code": "oculus",
+    "versionCode": "146202809",
+    "versionName": "5.7.8.144932646"
+  },
+  "device": {
+    "name": "Oculus Go",
+    "deviceProduct": "Pacific",
+    "serial": "1KWPH812ZF8202"
+  }
+}]

--- a/examples/tests/WebAudio/decode_multiple2.html
+++ b/examples/tests/WebAudio/decode_multiple2.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>WebAudio decode blocking</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background:#fff;
+				padding:0;
+				margin:0;
+				font-weight: bold;
+				overflow:hidden;
+			}
+		</style>
+	</head>
+	<body>
+		<span>No worry, this test renders nothing.</span>
+
+		<script>
+
+			function loadOption( key ) {
+
+				var options = location.href.split( '?' )[ 1 ];
+
+				if ( ! options ) return null;
+
+				var optionArray = options.split( '&' );
+
+				for ( var i = 0, il = optionArray.length; i < il; i ++ ) {
+
+					var tmp = optionArray[ i ].split( '=' );
+
+					if ( tmp[ 0 ].toLowerCase() === key ) return tmp[ 1 ];
+
+				}
+
+				return null;
+
+			}
+
+			var num = parseInt( loadOption( 'num' ) ) || 5;
+			var format = loadOption( 'format' ) || '';
+
+			var decodingNum = 0;
+			var playingNum = 0;
+
+			startMusic();
+			animate();
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+			}
+
+			function startMusics() {
+
+				var url = format.toLowerCase() === 'mp3' ? '358232_j_s_song.mp3' : '358232_j_s_song.ogg';
+				var context = new AudioContext();
+
+				for ( var i = 0; i < n; i ++ ) {
+
+					loadMusics( url, context );
+
+				}
+
+			}
+
+			function loadMusics( url, context ) {
+
+				fetch( url )
+					.then( response => {
+
+						return response.arrayBuffer();
+
+					} )
+					.then( arrayBuffer => {
+
+						if ( decodingNum === 0 && playingNum === 0 ) {
+
+							startProfile();
+
+						}
+
+						decodingNum ++;
+						return context.decodeAudioData( arrayBuffer );
+
+					} )
+					.then( audioBuffer => {
+
+						decodingNum --;
+						playingNum ++;
+
+						if ( playingNum === num ) {
+
+							endProfile();
+
+						}
+
+						var source = context.createBufferSource();
+						source.buffer = audioBuffer;
+						source.connect( context.destination );
+						source.start( 0, 0, 10 );
+
+					} );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/examples/tests/raw/performance_drawcall2.html
+++ b/examples/tests/raw/performance_drawcall2.html
@@ -1,0 +1,744 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>drawcall</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background:#fff;
+				padding:0;
+				margin:0;
+				font-weight: bold;
+				overflow:hidden;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script id="vertexShader" type="x-shader/x-vertex">
+precision highp float;
+precision highp int;
+
+attribute vec3 position;
+attribute vec3 normal;
+
+uniform mat4 modelViewMatrix;
+uniform mat3 normalMatrix;
+uniform mat4 projectionMatrix;
+
+varying vec3 vNormal;
+
+void main() {
+
+	vec3 objectNormal = vec3( normal );
+	vec3 transformedNormal = normalMatrix * objectNormal;
+	vNormal = normalize( transformedNormal );
+
+	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+	gl_Position = projectionMatrix * mvPosition;
+
+}
+		</script>
+
+		<script id="fragmentShader" type="x-shader/x-fragment">
+precision highp float;
+precision highp int;
+
+varying vec3 vNormal;
+
+vec3 packNormalToRGB( const in vec3 normal ) {
+
+	return normalize( normal ) * 0.5 + 0.5;
+
+}
+
+void main() {
+
+	vec3 normal = normalize( vNormal );
+	gl_FragColor = vec4( packNormalToRGB( normal ), 1.0 );
+
+}
+		</script>
+
+		<script>
+
+function Vector3( x, y, z ) {
+
+	this.x = x || 0;
+	this.y = y || 0;
+	this.z = z || 0;
+
+}
+
+Object.assign( Vector3.prototype, {
+
+} );
+
+function Quaternion( x, y, z, w ) {
+
+	this._x = x || 0;
+	this._y = y || 0;
+	this._z = z || 0;
+	this._w = ( w !== undefined ) ? w : 1;
+
+}
+
+Object.assign( Quaternion.prototype, {
+
+} );
+
+function Matrix3() {
+
+	this.elements = [
+
+		1, 0, 0,
+		0, 1, 0,
+		0, 0, 1
+
+	];
+
+}
+
+Object.assign( Matrix3.prototype, {
+
+	set: function ( n11, n12, n13, n21, n22, n23, n31, n32, n33 ) {
+
+		var te = this.elements;
+
+		te[ 0 ] = n11; te[ 1 ] = n21; te[ 2 ] = n31;
+		te[ 3 ] = n12; te[ 4 ] = n22; te[ 5 ] = n32;
+		te[ 6 ] = n13; te[ 7 ] = n23; te[ 8 ] = n33;
+
+		return this;
+
+	},
+
+	getNormalMatrix: function ( matrix4 ) {
+
+		return this.setFromMatrix4( matrix4 ).getInverse( this ).transpose();
+
+	},
+
+	setFromMatrix4: function ( m ) {
+
+		var me = m.elements;
+
+		this.set(
+
+			me[ 0 ], me[ 4 ], me[ 8 ],
+			me[ 1 ], me[ 5 ], me[ 9 ],
+			me[ 2 ], me[ 6 ], me[ 10 ]
+
+		);
+
+		return this;
+
+	},
+
+	getInverse: function ( matrix, throwOnDegenerate ) {
+
+		var me = matrix.elements,
+			te = this.elements,
+
+			n11 = me[ 0 ], n21 = me[ 1 ], n31 = me[ 2 ],
+			n12 = me[ 3 ], n22 = me[ 4 ], n32 = me[ 5 ],
+			n13 = me[ 6 ], n23 = me[ 7 ], n33 = me[ 8 ],
+
+			t11 = n33 * n22 - n32 * n23,
+			t12 = n32 * n13 - n33 * n12,
+			t13 = n23 * n12 - n22 * n13,
+
+			det = n11 * t11 + n21 * t12 + n31 * t13;
+
+		if ( det === 0 ) {
+
+			var msg = "THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0";
+
+			if ( throwOnDegenerate === true ) {
+
+				throw new Error( msg );
+
+			} else {
+
+				console.warn( msg );
+
+			}
+
+			return this.identity();
+
+		}
+
+		var detInv = 1 / det;
+
+		te[ 0 ] = t11 * detInv;
+		te[ 1 ] = ( n31 * n23 - n33 * n21 ) * detInv;
+		te[ 2 ] = ( n32 * n21 - n31 * n22 ) * detInv;
+
+		te[ 3 ] = t12 * detInv;
+		te[ 4 ] = ( n33 * n11 - n31 * n13 ) * detInv;
+		te[ 5 ] = ( n31 * n12 - n32 * n11 ) * detInv;
+
+		te[ 6 ] = t13 * detInv;
+		te[ 7 ] = ( n21 * n13 - n23 * n11 ) * detInv;
+		te[ 8 ] = ( n22 * n11 - n21 * n12 ) * detInv;
+
+		return this;
+
+	},
+
+	transpose: function () {
+
+		var tmp, m = this.elements;
+
+		tmp = m[ 1 ]; m[ 1 ] = m[ 3 ]; m[ 3 ] = tmp;
+		tmp = m[ 2 ]; m[ 2 ] = m[ 6 ]; m[ 6 ] = tmp;
+		tmp = m[ 5 ]; m[ 5 ] = m[ 7 ]; m[ 7 ] = tmp;
+
+		return this;
+
+	}
+
+} );
+
+function Matrix4() {
+
+	this.elements = [
+
+		1, 0, 0, 0,
+		0, 1, 0, 0,
+		0, 0, 1, 0,
+		0, 0, 0, 1
+
+	];
+
+}
+
+Object.assign( Matrix4.prototype, {
+
+	set: function ( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 ) {
+
+		var te = this.elements;
+
+		te[ 0 ] = n11; te[ 4 ] = n12; te[ 8 ] = n13; te[ 12 ] = n14;
+		te[ 1 ] = n21; te[ 5 ] = n22; te[ 9 ] = n23; te[ 13 ] = n24;
+		te[ 2 ] = n31; te[ 6 ] = n32; te[ 10 ] = n33; te[ 14 ] = n34;
+		te[ 3 ] = n41; te[ 7 ] = n42; te[ 11 ] = n43; te[ 15 ] = n44;
+
+		return this;
+
+	},
+
+	copy: function ( m ) {
+
+		var te = this.elements;
+		var me = m.elements;
+
+		te[ 0 ] = me[ 0 ]; te[ 1 ] = me[ 1 ]; te[ 2 ] = me[ 2 ]; te[ 3 ] = me[ 3 ];
+		te[ 4 ] = me[ 4 ]; te[ 5 ] = me[ 5 ]; te[ 6 ] = me[ 6 ]; te[ 7 ] = me[ 7 ];
+		te[ 8 ] = me[ 8 ]; te[ 9 ] = me[ 9 ]; te[ 10 ] = me[ 10 ]; te[ 11 ] = me[ 11 ];
+		te[ 12 ] = me[ 12 ]; te[ 13 ] = me[ 13 ]; te[ 14 ] = me[ 14 ]; te[ 15 ] = me[ 15 ];
+
+		return this;
+
+	},
+
+	multiplyMatrices: function ( a, b ) {
+
+		var ae = a.elements;
+		var be = b.elements;
+		var te = this.elements;
+
+		var a11 = ae[ 0 ], a12 = ae[ 4 ], a13 = ae[ 8 ], a14 = ae[ 12 ];
+		var a21 = ae[ 1 ], a22 = ae[ 5 ], a23 = ae[ 9 ], a24 = ae[ 13 ];
+		var a31 = ae[ 2 ], a32 = ae[ 6 ], a33 = ae[ 10 ], a34 = ae[ 14 ];
+		var a41 = ae[ 3 ], a42 = ae[ 7 ], a43 = ae[ 11 ], a44 = ae[ 15 ];
+
+		var b11 = be[ 0 ], b12 = be[ 4 ], b13 = be[ 8 ], b14 = be[ 12 ];
+		var b21 = be[ 1 ], b22 = be[ 5 ], b23 = be[ 9 ], b24 = be[ 13 ];
+		var b31 = be[ 2 ], b32 = be[ 6 ], b33 = be[ 10 ], b34 = be[ 14 ];
+		var b41 = be[ 3 ], b42 = be[ 7 ], b43 = be[ 11 ], b44 = be[ 15 ];
+
+		te[ 0 ] = a11 * b11 + a12 * b21 + a13 * b31 + a14 * b41;
+		te[ 4 ] = a11 * b12 + a12 * b22 + a13 * b32 + a14 * b42;
+		te[ 8 ] = a11 * b13 + a12 * b23 + a13 * b33 + a14 * b43;
+		te[ 12 ] = a11 * b14 + a12 * b24 + a13 * b34 + a14 * b44;
+
+		te[ 1 ] = a21 * b11 + a22 * b21 + a23 * b31 + a24 * b41;
+		te[ 5 ] = a21 * b12 + a22 * b22 + a23 * b32 + a24 * b42;
+		te[ 9 ] = a21 * b13 + a22 * b23 + a23 * b33 + a24 * b43;
+		te[ 13 ] = a21 * b14 + a22 * b24 + a23 * b34 + a24 * b44;
+
+		te[ 2 ] = a31 * b11 + a32 * b21 + a33 * b31 + a34 * b41;
+		te[ 6 ] = a31 * b12 + a32 * b22 + a33 * b32 + a34 * b42;
+		te[ 10 ] = a31 * b13 + a32 * b23 + a33 * b33 + a34 * b43;
+		te[ 14 ] = a31 * b14 + a32 * b24 + a33 * b34 + a34 * b44;
+
+		te[ 3 ] = a41 * b11 + a42 * b21 + a43 * b31 + a44 * b41;
+		te[ 7 ] = a41 * b12 + a42 * b22 + a43 * b32 + a44 * b42;
+		te[ 11 ] = a41 * b13 + a42 * b23 + a43 * b33 + a44 * b43;
+		te[ 15 ] = a41 * b14 + a42 * b24 + a43 * b34 + a44 * b44;
+
+		return this;
+
+	},
+
+	compose: function ( position, quaternion, scale ) {
+
+		var te = this.elements;
+
+		var x = quaternion._x, y = quaternion._y, z = quaternion._z, w = quaternion._w;
+		var x2 = x + x,	y2 = y + y, z2 = z + z;
+		var xx = x * x2, xy = x * y2, xz = x * z2;
+		var yy = y * y2, yz = y * z2, zz = z * z2;
+		var wx = w * x2, wy = w * y2, wz = w * z2;
+
+		var sx = scale.x, sy = scale.y, sz = scale.z;
+
+	        te[ 0 ] = ( 1 - ( yy + zz ) ) * sx;
+	        te[ 1 ] = ( xy + wz ) * sx;
+	        te[ 2 ] = ( xz - wy ) * sx;
+	        te[ 3 ] = 0;
+
+	        te[ 4 ] = ( xy - wz ) * sy;
+	        te[ 5 ] = ( 1 - ( xx + zz ) ) * sy;
+	        te[ 6 ] = ( yz + wx ) * sy;
+	        te[ 7 ] = 0;
+
+	        te[ 8 ] = ( xz + wy ) * sz;
+	        te[ 9 ] = ( yz - wx ) * sz;
+	        te[ 10 ] = ( 1 - ( xx + yy ) ) * sz;
+	        te[ 11 ] = 0;
+
+	        te[ 12 ] = position.x;
+	        te[ 13 ] = position.y;
+	        te[ 14 ] = position.z;
+	        te[ 15 ] = 1;
+
+	        return this;
+
+	}
+
+} );
+
+function Object3D() {
+
+	this.parent = null;
+	this.children = [];
+
+	var position = new Vector3();
+	var quaternion = new Quaternion();
+	var scale = new Vector3( 1, 1, 1 );
+
+	Object.defineProperties( this, {
+		position: {
+			configurable: true,
+			enumerable: true,
+			value: position
+		},
+		quaternion: {
+			configurable: true,
+			enumerable: true,
+			value: quaternion
+		},
+		scale: {
+			configurable: true,
+			enumerable: true,
+			value: scale
+		},
+		modelViewMatrix: {
+			value: new Matrix4()
+		},
+		normalMatrix: {
+			value: new Matrix3()
+		}
+	} );
+
+	this.matrix = new Matrix4();
+	this.matrixWorld = new Matrix4();
+
+	this.matrixAutoUpdate = Object3D.DefaultMatrixAutoUpdate;
+	this.matrixWorldNeedsUpdate = false;
+
+}
+
+Object3D.DefaultMatrixAutoUpdate = true;
+
+Object.assign( Object3D.prototype, {
+
+	add: function ( object ) {
+
+		object.parent = this;
+		this.children.push( object );
+
+		return this;
+
+	},
+
+	updateMatrix: function () {
+
+		this.matrix.compose( this.position, this.quaternion, this.scale );
+
+		this.matrixWorldNeedsUpdate = true;
+
+	},
+
+	updateMatrixWorld: function ( force ) {
+
+		if ( this.matrixAutoUpdate ) this.updateMatrix();
+
+		if ( this.matrixWorldNeedsUpdate || force ) {
+
+			if ( this.parent === null ) {
+
+				this.matrixWorld.copy( this.matrix );
+
+			} else {
+
+				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+
+			}
+
+			this.matrixWorldNeedsUpdate = false;
+
+			force = true;
+
+		}
+
+		// update children
+
+		var children = this.children;
+
+		for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+			children[ i ].updateMatrixWorld( force );
+
+		}
+
+	}
+
+} );
+		</script>
+
+		<script>
+
+			function loadOption( key ) {
+
+				var options = location.href.split( '?' )[ 1 ];
+
+				if ( ! options ) return null;
+
+				var optionArray = options.split( '&' );
+
+				for ( var i = 0, il = optionArray.length; i < il; i ++ ) {
+
+					var tmp = optionArray[ i ].split( '=' );
+
+					if ( tmp[ 0 ].toLowerCase() === key ) return tmp[ 1 ];
+
+				}
+
+				return null;
+
+			}
+
+			var objectNum = parseInt( loadOption( 'num' ) ) || 10;
+			var objects;
+			var container, canvas, gl;
+
+			var positionData, normalData, indexData;
+
+			var cameraProjectionMatrix = new Matrix4();
+			cameraProjectionMatrix.set(
+				0.8864625814548678, 0, 0, 0,
+				0, 1.7320508075688774, 0, 0,
+				0, 0, -1.0002000200020003, -2.000200020002,
+				0, 0, -1 , 0
+			);
+
+			var cameraMatrixWorldInverse = new Matrix4();
+			cameraMatrixWorldInverse.set(
+				1, 0, 0, 0,
+				0, 1, 0, -1.6,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			);
+
+			var float32ArrayMatrix3 = new Float32Array( 9 );
+			var float32ArrayMatrix4 = new Float32Array( 16 );
+
+			var glPositionBuffer, glNormalBuffer, glIndexBuffer, glProgram;
+			var glAttributeLocations = {};
+			var glUniformLocations = {};
+
+			var windowWidth = window.innerWidth;
+			var windowHeight = window.innerHeight;
+			var devicePixelRatio = window.devicePixelRatio;
+
+			loadData( function () {
+
+				init();
+				initWebGLResources();
+				animate();
+
+			} );
+
+			function loadData( onLoad ) {
+
+				var request = new XMLHttpRequest();
+				request.open( 'GET', 'suzanne.json', true );
+				request.responseType = 'json';
+
+				request.addEventListener( 'load', function ( event ) {
+
+					var response = request.response;
+					positionData = new Float32Array( response.position );
+					normalData = new Float32Array( response.normal );
+					indexData = new Uint16Array( response.index );
+
+					expandData( 1000 );
+
+					onLoad();
+
+				} );
+
+				request.addEventListener( 'error', function ( event ) {
+
+					console.error( event );
+
+				} );
+
+				request.addEventListener( 'abort', function ( event ) {
+
+					console.error( event );
+
+				} );
+
+				request.send( null );
+			}
+
+			function expandData( n ) {
+
+				var positionDataLength = positionData.length;
+				var normalDataLength = normalData.length;
+				var indexDataLength = indexData.length;
+
+				var newPositionData = new Float32Array( positionDataLength * n );
+				var newNormalData = new Float32Array( normalDataLength * n );
+				var newIndexData = new Uint16Array( indexDataLength * n );
+
+				for ( var i = 0; i < n; i ++ ) {
+
+					for ( var j = 0; j < positionDataLength; j ++ ) {
+
+						newPositionData[ positionDataLength * i + j ] = positionData[ j ] + i * 0.001;
+
+					}
+
+					for ( var j = 0; j < normalDataLength; j ++ ) {
+
+						newNormalData[ normalDataLength * i + j ] = normalData[ j ];
+
+					}
+
+					for ( var j = 0; j < indexDataLength; j ++ ) {
+
+						newIndexData[ indexDataLength * i + j ] = indexData[ j ] + indexDataLength * i;
+
+					}
+
+				}
+
+				positionData = newPositionData;
+				normalData = newNormalData;
+				indexData = newIndexData;
+
+			}
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
+				canvas.width = windowWidth * devicePixelRatio;
+				canvas.height = windowHeight * devicePixelRatio;
+				canvas.style.width = windowWidth + 'px';
+				canvas.style.height = windowHeight + 'px';
+
+				gl = canvas.getContext( 'webgl' );
+				gl.viewport( 0, 0, windowWidth * devicePixelRatio, windowHeight * devicePixelRatio );
+
+				container.appendChild( canvas );
+
+				root = new Object3D();
+
+				objects = [];
+
+				for ( var i = 0; i < objectNum; i ++ ) {
+
+					var object = new Object3D();
+
+					object.position.x = Math.random() * 1000 - 500;
+					object.position.y = Math.random() * 1000 - 500;
+					object.position.z = Math.random() * 1000 - 500 - 3000;
+					object.scale.x = object.scale.y = object.scale.z = Math.random() * 50 + 100;
+					object.updateMatrix();
+					object.matrixAutoUpdate = false;
+					objects.push( object );
+
+					root.add( object );
+
+				}
+
+				objects.sort( function ( a, b ) { return b.position.z - a.position.z; } );
+
+				root.updateMatrixWorld( true );
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function initWebGLResources() {
+
+				// initialize configurations
+
+				gl.disable( gl.BLEND );
+				gl.enable( gl.CULL_FACE );
+				gl.enable( gl.DEPTH_TEST );
+				gl.depthFunc( gl.LEQUAL );
+				gl.depthMask( true );
+				gl.colorMask( true, true, true, true );
+
+				// initialize vertex and fragment shaders
+
+				var vertexShaderCode = document.getElementById( 'vertexShader' ).text;
+				var fragmentShaderCode = document.getElementById( 'fragmentShader' ).text;
+
+				var vertexShader = gl.createShader( gl.VERTEX_SHADER );
+				gl.shaderSource( vertexShader, vertexShaderCode );
+				gl.compileShader( vertexShader );
+
+				if ( ! gl.getShaderParameter( vertexShader, gl.COMPILE_STATUS ) ) {
+
+					console.error( gl.getShaderInfoLog( vertexShader ) );
+
+				}
+
+				var fragmentShader = gl.createShader( gl.FRAGMENT_SHADER );
+				gl.shaderSource( fragmentShader, fragmentShaderCode );
+				gl.compileShader( fragmentShader );
+
+				if ( ! gl.getShaderParameter( fragmentShader, gl.COMPILE_STATUS ) ) {
+
+					console.error( gl.getShaderInfoLog( fragmentShader ) );
+
+				}
+
+				// initialize program
+
+				glProgram = gl.createProgram();
+				gl.attachShader( glProgram, vertexShader );
+				gl.attachShader( glProgram, fragmentShader );
+
+				gl.linkProgram( glProgram );
+
+				if ( ! gl.getProgramParameter( glProgram, gl.LINK_STATUS ) ) {
+
+					console.error( gl.getProgramInfoLog( glProgram ) );
+
+				}
+
+				glAttributeLocations.position = gl.getAttribLocation( glProgram, 'position' );
+				glAttributeLocations.normal = gl.getAttribLocation( glProgram, 'normal' );
+
+				glUniformLocations.modelViewMatrix = gl.getUniformLocation( glProgram, 'modelViewMatrix' );
+				glUniformLocations.normalMatrix = gl.getUniformLocation( glProgram, 'normalMatrix' );
+				glUniformLocations.projectionMatrix = gl.getUniformLocation( glProgram, 'projectionMatrix' );
+
+				// initialize buffers
+
+				glPositionBuffer = gl.createBuffer();
+				gl.bindBuffer( gl.ARRAY_BUFFER, glPositionBuffer );
+				gl.bufferData( gl.ARRAY_BUFFER, positionData, gl.STATIC_DRAW );
+
+				glNormalBuffer = gl.createBuffer();
+				gl.bindBuffer( gl.ARRAY_BUFFER, glNormalBuffer );
+				gl.bufferData( gl.ARRAY_BUFFER, normalData, gl.STATIC_DRAW );
+
+				glIndexBuffer = gl.createBuffer();
+				gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, glIndexBuffer );
+				gl.bufferData( gl.ELEMENT_ARRAY_BUFFER, indexData, gl.STATIC_DRAW );
+
+				//
+
+				gl.useProgram( glProgram );
+				gl.enableVertexAttribArray( glAttributeLocations.position );
+				gl.enableVertexAttribArray( glAttributeLocations.normal );
+
+			}
+
+			function onWindowResize() {
+
+				windowWidth = window.innerWidth;
+				windowHeight = window.innerHeight;
+
+				canvas.width = windowWidth * devicePixelRatio;
+				canvas.height = windowHeight * devicePixelRatio;
+				canvas.style.width = windowWidth + 'px';
+				canvas.style.height = windowHeight + 'px';
+
+				gl.viewport( 0, 0, windowWidth * devicePixelRatio, windowHeight * devicePixelRatio );
+
+				// @TODO update cameraProjectionMatrix
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
+
+				gl.clear( gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT );
+
+				// bind buffer just once for all objects
+
+				gl.bindBuffer( gl.ARRAY_BUFFER, glPositionBuffer );
+				gl.vertexAttribPointer( glAttributeLocations.position, 3, gl.FLOAT, false, 0, 0 );
+
+				gl.bindBuffer( gl.ARRAY_BUFFER, glNormalBuffer );
+				gl.vertexAttribPointer( glAttributeLocations.normal, 3, gl.FLOAT, false, 0, 0 );
+
+				gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, glIndexBuffer );
+
+				float32ArrayMatrix4.set( cameraProjectionMatrix.elements );
+				gl.uniformMatrix4fv( glUniformLocations.projectionMatrix, false, float32ArrayMatrix4 );
+
+				var count = indexData.length;
+
+				for ( var i = 0, il = objects.length; i < il; i ++ ) {
+
+					var object = objects[ i ];
+
+					object.modelViewMatrix.multiplyMatrices( cameraMatrixWorldInverse, object.matrixWorld );
+					float32ArrayMatrix4.set( object.modelViewMatrix.elements );
+					gl.uniformMatrix4fv( glUniformLocations.modelViewMatrix, false, float32ArrayMatrix4 );
+
+					object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+					float32ArrayMatrix3.set( object.normalMatrix.elements );
+					gl.uniformMatrix3fv( glUniformLocations.normalMatrix, false, float32ArrayMatrix3 );
+
+					gl.drawElements( gl.TRIANGLES, count, gl.UNSIGNED_SHORT, 0 );
+
+				}
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -800,8 +800,8 @@ window.TESTER = {
       setTimeout(() => {
         navigator.getVRDisplays().then(displays => {
           var device = displays[0];
-          //if (device.isPresenting) device.exitPresent();
           if (device) {
+            //if (device.isPresenting) device.exitPresent();
             device.requestPresent( [ { source: canvas } ] );
           }
         }), 2000}); // @fix to make it work on FxR


### PR DESCRIPTION
If `autoenter-xr` is `true` `injectAutoEnterXR()` is called to enter VR mode in test. `injectAutoEnterXR()` seems to expect valid display exists. Then it causes an error in case there is no display for example on desktop. So `webvr_cubes` test doesn't run correctly on desktop. This PR avoid the error by not entering VR mode if there is no display.

Alternative is failing test with no display if we restrict the platform to have display in case `autoenter-xr` is `true`.