### PR TITLE
Add autoenterXR stats on results, fixed #63

### DIFF
--- a/dist/webgfx-tests.js
+++ b/dist/webgfx-tests.js
@@ -3229,6 +3229,7 @@
 	          perf: this.stats.getStatsSummary(),
 	          webgl: WebGLStats$1.getSummary()
 	        },
+	        autoEnterXR: this.autoEnterXR,
 	        webaudio: WebAudioHook.stats,
 	        numFrames: this.numFramesToRender,
 	        totalTime: totalTime,
@@ -3639,8 +3640,12 @@
 
 	    this.timeStart = performance.realNow();
 	  },
-
+	  autoenterXR: {
+	    requested: false,
+	    succesful: false
+	  },
 	  injectAutoEnterXR: function(canvas) {
+	    this.autoEnterXR.requested = true;
 	    if (navigator.getVRDisplays) {
 	      setTimeout(() => {
 	        navigator.getVRDisplays().then(displays => {
@@ -3648,7 +3653,7 @@
 	          //if (device.isPresenting) device.exitPresent();
 	          if (device) {
 	            device.requestPresent( [ { source: canvas } ] )
-	              .then(x => { console.log('autoenter XR successful'); })
+	              .then(x => { console.log('autoenter XR successful'); this.autoEnterXR.succesful = true; })
 	              .catch(x => { console.log('autoenter XR failed'); });
 	          }
 	        });

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -432,6 +432,7 @@ window.TESTER = {
           perf: this.stats.getStatsSummary(),
           webgl: WebGLStats.getSummary()
         },
+        autoEnterXR: this.autoEnterXR,
         webaudio: WebAudioHook.stats,
         numFrames: this.numFramesToRender,
         totalTime: totalTime,
@@ -843,8 +844,12 @@ window.TESTER = {
 
     this.timeStart = performance.realNow();
   },
-
+  autoenterXR: {
+    requested: false,
+    successful: false
+  },
   injectAutoEnterXR: function(canvas) {
+    this.autoEnterXR.requested = true;
     if (navigator.getVRDisplays) {
       setTimeout(() => {
         navigator.getVRDisplays().then(displays => {
@@ -852,7 +857,7 @@ window.TESTER = {
           //if (device.isPresenting) device.exitPresent();
           if (device) {
             device.requestPresent( [ { source: canvas } ] )
-              .then(x => { console.log('autoenter XR successful'); })
+              .then(x => { console.log('autoenter XR successful'); this.autoEnterXR.successful = true; })
               .catch(x => { console.log('autoenter XR failed'); });
           }
         })


### PR DESCRIPTION
Add stats to the results to know if `autoenterXR` was requested and if it was successful or not
```
  autoEnterXR: {
    requested: true,
    successful: true
  },
```