### PR TITLE
Fix #47 Add webaudio to summary

### DIFF
--- a/src/main/summary/flatten.js
+++ b/src/main/summary/flatten.js
@@ -14,8 +14,13 @@ module.exports = function flatten(results) {
       values[id] = test.stats.perf[id].avg;
     }
     for (let id in test.stats.webgl) {
-      values[id] = test.stats.webgl[id].avg;
+      values['webgl_' + id] = test.stats.webgl[id].avg;
     }
+
+    for (let id in test.webaudio) {
+      values['webaudio_' + id] = test.webaudio[id];
+    }
+
     return {
       values: values,
       info: {


### PR DESCRIPTION
Added `webaudio_` results to summary
![image](https://user-images.githubusercontent.com/782511/56085185-71666f80-5e3f-11e9-93d1-a92de2a91455.png)

* Also added preffix `webgl_` to WebGL stats