### PR TITLE
Fix download button

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -478,11 +478,11 @@ window.TESTER = {
   },
 
   benchmarkFinished: function () {
+    this.injectBenchmarkFinishedHTML();
+
     if (this.inputRecorder) {
       this.addInputDownloadButton();
     }
-
-    this.injectBenchmarkFinishedHTML();
 
     try {
       var data = this.canvas.toDataURL("image/png");


### PR DESCRIPTION
Currently download buttons for image and input are broken. This PR fixes.

`addInputDownloadButton()` attempts to get element whose id is `test_finished` but `test_finished` div element is added in `injectBenchmarkFinishedHTML()`. So I think calling `injectBenchmarkFinishedHTML()` before `addInputDownloadButton()` looks right order.