### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Browsers on device: PC (serial: )
 ## Start server
 Usage:
 ```
-$ gfxstart start-server [options]
+$ webgfx-tests start-server [options]
 ```
 
 * `-h, --help`: Show the previous help text.


### PR DESCRIPTION
If I'm right, this line in Readme

```
$ gfxstart start-server [options]
```

should be

```
$ webgfx-tests start-server [options]
```

shouldn't it?