### PR TITLE
Enable to run test on port specified by command line option

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -477,7 +477,8 @@ program
 
               var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions);
               await testsManager.runTests({
-                apkFilename: apkFilename
+                apkFilename: apkFilename,
+                port: options.port
               });
             }
             reader.close();
@@ -518,7 +519,9 @@ program
           //console.log(generalOptions);
 
           var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions, {});
-          await testsManager.runTests({});
+          await testsManager.runTests({
+            port: options.port
+          });
           onTestsFinish();
         }
       });

--- a/src/main/testsmanager/device.js
+++ b/src/main/testsmanager/device.js
@@ -115,8 +115,8 @@ TestsManager.prototype = {
     });
 
     const serverIP = this.generalOptions ? 'localhost' : internalIp.v4.sync() || 'localhost';
-    //@fixme port from params
-    const baseURL = `http://${serverIP}:3000/`;
+    const port = extraOptions.port || 3000;
+    const baseURL = `http://${serverIP}:${port}/`;
 
     var options = {
       showKeys: false,


### PR DESCRIPTION
`webgfx-tests` takes `-p` option which specifies the port on which test server runs. But the port is hardcoded in `device.js` so the test can't run if `-p` option is set. This PR fixes this problem.