### PR TITLE
Allow testing external site

### DIFF
--- a/examples/tests/tests.json
+++ b/examples/tests/tests.json
@@ -89,5 +89,18 @@
     "mobile": true,
     "interactive": true,
     "skipReferenceImageTest": true
+  },
+  {
+    "id": "three",
+    "engine": "three.js",
+    "url": "https://threejs.org/examples/webgl_animation_cloth.html",
+    "name": "Three.js Animation Cloth",
+    "mobile": true,
+    "apis": [
+      "WebGL"
+    ],
+    "numFrames": 400,
+    "interactive": true,
+    "skipReferenceImageTest": true
   }
 ]

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -389,7 +389,9 @@ window.TESTER = {
   },
 
   initServer: function () {
-    var serverUrl = 'http://' + GFXTESTS_CONFIG.serverIP + ':8888';
+    const protocol = location.href.split(':')[0];
+    // @Fixme: Port should be configurable by commandline option
+    const serverUrl = protocol + '://' + GFXTESTS_CONFIG.serverIP + ':8888';
 
     this.socket = io.connect(serverUrl);
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -192,6 +192,7 @@ program
   .option("-b, --launchbrowser <browser name>", "Which browser to use to launch the front page")
   .option("-c, --configfile <configFile>", "Config file (default webgfx-tests.config.json)")
   .option("-v, --verbose", "Show all the information available")
+  .option("-s, --secure", "Run HTTPS Server. You need key.pem and cert.pem.")
   .action(async options => {
     const configfile = options.configfile || 'webgfx-tests.config.json';
 
@@ -200,10 +201,10 @@ program
       console.log(`${chalk.red('ERROR')}: error loading config file: ${chalk.yellow(configfile)}`);
     } else {
 
-      initHTTPServer(options.port, config, options.verbose);
+      initHTTPServer(options.port, config, options.verbose, options.secure);
       initWebSocketServer(options.wsport, (data, io) => {
         io.emit('test_finished', data);
-      }, options.verbose);
+      }, options.verbose, options.secure);
 
       if (options.launchbrowser) {
         var devices = getDevices(options.adb);
@@ -251,6 +252,7 @@ program
   .option("-r, --overrideparams <additional parameters>", "Override parameters on individual execution (eg: \"fake-webgl&width=800&height=600\"")
   .option("-v, --verbose", "Show all the info available")
   .option("-w, --wsport <port_number>", "WebSocket Port number (Default 8888)")
+  .option("-s, --secure", "Run HTTPS Server. You need key.pem and cert.pem.")
   .action((testsIDs, options) => {
     const configfile = options.configfile || 'webgfx-tests.config.json';
 
@@ -324,7 +326,7 @@ program
         }
       }
 
-      initHTTPServer(options.port, config, options.verbose);
+      initHTTPServer(options.port, config, options.verbose, options.secure);
       var websockets = initWebSocketServer(options.wsport, {
         testFinished: (data, io) => {
           io.emit('test_finished', data);
@@ -392,7 +394,7 @@ program
             runningBrowser.hardwareStats.enabled = true;
           }
         }
-      }, options.verbose);
+      }, options.verbose, options.secure);
 
 
 
@@ -478,7 +480,8 @@ program
               var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions);
               await testsManager.runTests({
                 apkFilename: apkFilename,
-                port: options.port
+                port: options.port,
+                secureServer: !!options.secure
               });
             }
             reader.close();
@@ -520,7 +523,8 @@ program
 
           var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions, {});
           await testsManager.runTests({
-            port: options.port
+            port: options.port,
+            secureServer: !!options.secure
           });
           onTestsFinish();
         }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -477,7 +477,8 @@ program
 
               var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions);
               await testsManager.runTests({
-                apkFilename: apkFilename
+                apkFilename: apkFilename,
+                port: options.port
               });
             }
             reader.close();
@@ -518,7 +519,9 @@ program
           //console.log(generalOptions);
 
           var testsManager = testsManagers[device.serial] = new TestUtils.TestsManager(device, testsToRun, browsersToRun, generalOptions, {});
-          await testsManager.runTests({});
+          await testsManager.runTests({
+            port: options.port
+          });
           onTestsFinish();
         }
       });

--- a/src/main/server/http_server.js
+++ b/src/main/server/http_server.js
@@ -12,6 +12,120 @@ const https = require('https');
 
 const baseFolder = '/../../../';
 
+const insertTestCode = (html, test, testsFolder, config, secure, port) => {
+  const $ = cheerio.load(html);
+  const head = $('head');
+  let referenceImageTest = true;
+
+  if (test.skipReferenceImageTest !== true) {
+    const referenceImageName = test.referenceImage || test.id;
+    const referenceImagesFolder = path.join(testsFolder, config.referenceImagesFolder);
+    const filepath = path.join(referenceImagesFolder, referenceImageName + '.png');
+
+    if (!fs.existsSync(filepath)) {
+      console.log(`ERROR: Reference image for test <${test.id}> "${referenceImageName}" not found! Disabling reference test. Please consider adding 'skipReferenceImageTest: true' to this test or generate a reference image.`);
+      referenceImageTest = false;
+    }
+  } else {
+    referenceImageTest = false;
+  }
+
+  test.serverIP = internalIp.v4.sync() || 'localhost';
+  const protocol = secure ? 'https' : 'http';
+
+  head.append(`<script>var GFXTESTS_CONFIG = ${JSON.stringify(test, null, 2)};</script>`);
+  if (referenceImageTest) {
+    head.append(`<script>var GFXTESTS_REFERENCEIMAGE_BASEURL = 'tests/${config.referenceImagesFolder}';</script>`);
+  }
+  // @todo Move socket.io reference to local
+  head.append('<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.1/socket.io.js"></script>')
+      .append(`<script src="${protocol}://${test.serverIP}:${port}/webgfx-tests.js"></script>`);
+
+  if (test.injectJS) {
+    console.log(`- Injecting JS: ${test.injectJS.path} (${test.injectJS.where})`);
+    switch (test.injectJS.where) {
+      case "HEAD":
+        head.append(`<script src="/tests/${test.injectJS.path}"></script>`);
+        break;
+      case "DEFER":
+        head.append(`<script src="/tests/${test.injectJS.path}" defer></script>`);
+        break;
+      case "CUSTOM":
+        {
+          const element = $(test.injectJS.selector);
+          element.append(`<script src="/tests/${test.injectJS.path}"></script>`);
+        }
+        break;
+      case "INSIDE":
+        {
+          // @REDEFINE
+          const element = $('script').last();
+          const injectPath = path.join(testsFolder, test.injectJS.path);
+          const customJS = fs.readFileSync(injectPath, 'utf8');
+          element.html(element.html() + customJS);
+        }
+        break;
+    }
+  }
+
+  return $.html();
+};
+
+// If testing external site via the test server,
+// we need to convert external resource URL to point to right URL
+const insertURLConversionCode = (html, oriUrl, secure, port) => {
+  const $ = cheerio.load(html);
+  const head = $('head');
+  const protocol = secure ? 'https' : 'http';
+  // Fixme: hostname should be able to be specified by command line option
+  const rootName = `${protocol}://localhost:${port}`;
+  const oriRootname = oriUrl.match(/^[^:]*:\/\/[^\/]*/)[0];
+  // Fixme: Optimize regex
+  const oriDirname = (oriUrl.match(/^[^:]*:\/\/.*\//) || oriUrl.match(/^[^:]*:\/\/.*$/))[0];
+
+  const escape = html => html.replace(/\//g, '\\/').replace(/\./g, '\\.');
+  const urlConversionChunk = `
+    // console.log('Before ', url); // for debug
+    url = url.replace(/^${escape(rootName + '/tests/' + oriRootname)}/, '${oriRootname}');
+    if (url.match(/^${escape(rootName)}/)) {
+      url = url.replace(/^${escape(rootName)}/, '${oriRootname}');
+    } else if (url.match(/^${escape('/')}/)) {
+      url = '${oriRootname}' + url;
+    } else if (url.match(/^${escape('.')}/)) {
+      url = '${oriDirname}' + url;
+    }
+    // console.log('After ', url); // for debug
+  `;
+
+  // Hook XMLHttpRequest
+  head.prepend(`
+    <script>
+      XMLHttpRequest.prototype._rawOpen = XMLHttpRequest.prototype.open;
+      XMLHttpRequest.prototype.open = function open(method, url) {
+        ${urlConversionChunk}
+        return this._rawOpen(method, url);
+      };
+    </script>
+  `);
+
+  // Hook fetch
+  head.prepend(`
+    <script>
+      window._rawFetch = fetch;
+      window.fetch = (url, init) => {
+        ${urlConversionChunk}
+        return window._rawFetch(url, init);
+      };
+    </script>
+  `);
+
+  // @TODO: Hook Image.src and others which access external resources
+
+  head.prepend(`<base href="${oriUrl}">`);
+
+  return $.html();
+};
+
 function initServer(port, config, verbose, secure) {
   port = port || 3000;
   verbose = verbose || false;
@@ -63,9 +177,25 @@ function initServer(port, config, verbose, secure) {
       var oriUrl = req.url.replace(/\/tests\//, '');;
       var url = oriUrl.split('?')[0]; // Remove params like /file.json?p=whatever
       var pathf = path.join(testsFolder, url);
-
       var ext = path.extname(url);
-      if (ext === '.html') {
+
+      if (oriUrl.match(/^https?:\/\//)) {
+        const candidateTests = config.tests.filter(test => test.url.split('?')[0] === url);
+        const test = candidateTests.find(test => oriUrl.indexOf(test.url) !== -1);
+        process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+        const request = https.get(oriUrl, response => {
+          let html = '';
+          response.on('data', chunk => {
+            // Question: Does chunk come in order?
+            html += chunk;
+          });
+          response.on('end', chunk => {
+            html = insertTestCode(html, test, testsFolder, config, secure, port);
+            html = insertURLConversionCode(html, oriUrl, secure, port);
+            res.send(html);
+          });
+        });
+      } else if (ext === '.html') {
         // @todo Check that the filename is the entry main
         //var test = config.tests.find(test => test.url === url.replace(/\/tests\//, ''));
         // We need to filter initially because two tests could share the same base url
@@ -73,54 +203,9 @@ function initServer(port, config, verbose, secure) {
         var test = candidateTests.find(test => oriUrl.indexOf(test.url) !== -1);
 
         if (test) {
-          var html = fs.readFileSync(pathf, 'utf8');
-          var $ = cheerio.load(html);
-          var head = $('head');
-          var referenceImageTest = true;
-
-          if (test.skipReferenceImageTest !== true) {
-            const referenceImageName = test.referenceImage || test.id;
-            const referenceImagesFolder = path.join(testsFolder, config.referenceImagesFolder);
-            const filepath = path.join(referenceImagesFolder, referenceImageName + '.png');
-
-            if (!fs.existsSync(filepath)) {
-              console.log(`ERROR: Reference image for test <${test.id}> "${referenceImageName}" not found! Disabling reference test. Please consider adding 'skipReferenceImageTest: true' to this test or generate a reference image.`);
-              referenceImageTest = false;
-            }
-          } else {
-            referenceImageTest = false;
-          }
-
-          test.serverIP = internalIp.v4.sync() || 'localhost';
-          head.append(`<script>var GFXTESTS_CONFIG = ${JSON.stringify(test, null, 2)};</script>`);
-          if (referenceImageTest) {
-            head.append(`<script>var GFXTESTS_REFERENCEIMAGE_BASEURL = 'tests/${config.referenceImagesFolder}';</script>`);
-          }
-          // @todo Move socket.io reference to local
-          head.append('<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.1/socket.io.js"></script>')
-              .append('<script src="/webgfx-tests.js"></script>');
-
-          if (test.injectJS) {
-            console.log(`- Injecting JS: ${test.injectJS.path} (${test.injectJS.where})`);
-            switch (test.injectJS.where) {
-              case "HEAD":
-                head.append(`<script src="/tests/${test.injectJS.path}"></script>`); break;
-              case "DEFER":
-                head.append(`<script src="/tests/${test.injectJS.path}" defer></script>`); break;
-              case "CUSTOM":
-                var element = $(test.injectJS.selector);
-                element.append(`<script src="/tests/${test.injectJS.path}"></script>`);
-                break;
-              case "INSIDE":
-                // @REDEFINE
-                var element = $('script').last();
-                const injectPath = path.join(testsFolder, test.injectJS.path);
-                var customJS = fs.readFileSync(injectPath, 'utf8');
-                element.html(element.html() + customJS);
-                break;
-            }
-          }
-
+          let html = fs.readFileSync(pathf, 'utf8');
+          html = insertTestCode(html, test, testsFolder, config, secure, port);
+          const $ = cheerio.load(html);
           res.send($.html());
         } else {
           res.send('No test found: ' + url);

--- a/src/main/server/http_server.js
+++ b/src/main/server/http_server.js
@@ -8,10 +8,11 @@ var path = require('path')
 const chalk = require('chalk');
 const internalIp = require('internal-ip');
 var bodyParser = require('body-parser')
+const https = require('https');
 
 const baseFolder = '/../../../';
 
-function initServer(port, config, verbose) {
+function initServer(port, config, verbose, secure) {
   port = port || 3000;
   verbose = verbose || false;
 
@@ -134,10 +135,21 @@ function initServer(port, config, verbose) {
       }
     });
 
-  server.listen(port, function(){
-    var serverIP = internalIp.v4.sync() || 'localhost';
-    console.log('* HTTP Tests server listening on ' + chalk.yellow(serverIP + ':' + port));
-  });
+  const serverIP = internalIp.v4.sync() || 'localhost';
+  if (secure) {
+    if (!fs.existsSync('./key.pem') || !fs.existsSync('./cert.pem')) {
+      console.log('You need key.pem and cert.pem files to run HTTPS server.');
+    }
+    https.createServer({
+      key: fs.readFileSync('./key.pem', 'utf8'),
+      cert: fs.readFileSync('./cert.pem', 'utf8')
+    }, server).listen(port);
+    console.log('* HTTPS Tests server listening on ' + chalk.yellow(serverIP + ':' + port));
+  } else {
+    server.listen(port, function(){
+      console.log('* HTTP Tests server listening on ' + chalk.yellow(serverIP + ':' + port));
+    });
+  }
 }
 
 module.exports = initServer;

--- a/src/main/server/websockets_server.js
+++ b/src/main/server/websockets_server.js
@@ -1,9 +1,11 @@
 var http = require('http');
+const https = require('https');
+const fs = require('fs');
 const PrettyPrint = require('../prettyprint');
 const chalk = require('chalk');
 
 //function initWebSocketServer(port, testFinishedCallback, verbose) {
-function initWebSocketServer(port, callbacks, verbose) {
+function initWebSocketServer(port, callbacks, verbose, secure) {
   verbose = verbose || false;
   port = port || 8888;
 
@@ -14,7 +16,7 @@ function initWebSocketServer(port, callbacks, verbose) {
     }
   }
 
-  var server = http.createServer(function(req,res){
+  const app = (req, res) => {
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Request-Method', '*');
@@ -25,9 +27,21 @@ function initWebSocketServer(port, callbacks, verbose) {
       res.end();
       return;
     }
+  };
 
-    // ...
-  });
+  let server;
+  if (secure) {
+    if (!fs.existsSync('./key.pem') || !fs.existsSync('./cert.pem')) {
+      console.log('You need key.pem and cert.pem files to run HTTPS server.');
+    }
+    server = https.createServer({
+      key: fs.readFileSync('./key.pem', 'utf8'),
+      cert: fs.readFileSync('./cert.pem', 'utf8')
+    }, app);
+  } else {
+    server = http.createServer(app);
+  }
+
   var io = require('socket.io').listen(server);
 
   io.set('origins', '*:*');

--- a/src/main/testsmanager/device.js
+++ b/src/main/testsmanager/device.js
@@ -116,7 +116,8 @@ TestsManager.prototype = {
 
     const serverIP = this.generalOptions ? 'localhost' : internalIp.v4.sync() || 'localhost';
     const port = extraOptions.port || 3000;
-    const baseURL = `http://${serverIP}:${port}/`;
+    const protocol = extraOptions.secureServer ? 'https' : 'http';
+    const baseURL = `${protocol}://${serverIP}:${port}/`;
 
     var options = {
       showKeys: false,

--- a/src/main/testsmanager/device.js
+++ b/src/main/testsmanager/device.js
@@ -115,8 +115,8 @@ TestsManager.prototype = {
     });
 
     const serverIP = this.generalOptions ? 'localhost' : internalIp.v4.sync() || 'localhost';
-    //@fixme port from params
-    const baseURL = `http://${serverIP}:3000/`;
+    const port = extraOptions.port || 3000;
+    const baseURL = `http://${serverIP}:${port}/`;
 
     var options = {
       showKeys: false,


### PR DESCRIPTION
Resolves #91.

As mentioned #91, currently `webgfx-tests` requires test to be on the local testing server. This PR allows testing external site.

The advantages are

* Users no longer need to clone/copy the external site to local for the test
* Enable testing the site which must run on an certain (dev) server

As an example, I added [Three.js official example](https://threejs.org/examples/webgl_animation_cloth.html) to `tests.json`.

Changes are
* If test URL starts with `http(s)://`, the local testing server transfers the external site while inserting testing code. (This is the trick to test external site on the local testing server.) External site runs on the local testing server, then it also inserts the code converting external resource absolute path (starting with `/`) and relative path (starting with `.`) to point to the right external resource path. 
* Add `-s` option for Secure testing server because external resource can require to be accessed from `https` site. To run Secure testing server, users need to create certification files with [mkcert](https://github.com/FiloSottile/mkcert) or something and place them as `key.pem` and `cert.pem` in their `webgfx-tests` directory.
* Similarly external resource can require to be accessed from certain port then this PR includes #92. So please review #92 first.

Regarding Mozilla Hubs (my original purpose for this feature), this change isn't good enough because some external Hubs resources seem to require restricted access, for example they seem to allow access only from a certain domain. I think we can resolve in Hubs side for example by relaxing access restrictions for the test.
