### PR TITLE
Introduce hasTestCode test option

### DIFF
--- a/src/main/testsmanager/browser.js
+++ b/src/main/testsmanager/browser.js
@@ -74,5 +74,5 @@ TestsManagerBrowser.prototype = {
     }
 
     window.open(url);
-   }
+  }
 }

--- a/src/main/testsmanager/common.js
+++ b/src/main/testsmanager/common.js
@@ -58,7 +58,12 @@ function buildTestURL(baseURL, test, mode, options, progress) {
     // console.log('Generated URL: ', url);
   }
 
-  url = baseURL + (mode === 'interactive' ? 'static/': 'tests/') + test.url + (test.url.indexOf('?') !== -1 ? '' : '?') + url;
+  // If test code is already manually embedded by user
+  // directly open the URL, not via the test server.
+  const baseTestURL = test.hasTestCode ? test.url :
+    baseURL + (mode === 'interactive' ? 'static/': 'tests/') + test.url;
+
+  url = baseTestURL + (test.url.indexOf('?') !== -1 ? '' : '?') + url;
   return url;
 }
 


### PR DESCRIPTION
Some complex applications, especially which require restrict access controls, may need to run on certain specific domains, not on `webgfx-tests` testing server. 

For such applications, I think it would be useful if we provide a way that user manually embeds testing code in their application and runs the test in their domain.

This PR introduces `hasTestCode` test option to enable it. If `hasTestCode` is `true`, `webgfx-tests` directly opens the application URL, not via the testing server.

With #92, #93, #94, and this PR, testing Mozilla Hubs with `webgfx-tests` is available.