### PR TITLE
Bump detect-browsers into the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cheerio": "^1.0.0-rc.3",
     "commander": "^2.20.3",
     "compression": "^1.7.4",
-    "detect-browsers": "^3.3.0",
+    "detect-browsers": "^5.0.5",
     "express": "^4.17.1",
     "fake-timers": "^0.1.2",
     "input-events-recorder": "^1.2.2",

--- a/src/main/devices/local-device.js
+++ b/src/main/devices/local-device.js
@@ -8,14 +8,14 @@ module.exports = {
   name: 'PC',
   getInstalledBrowsers: function() {
     return new Promise((resolve, reject) => {
-      detectBrowsers.getInstalledBrowsers()
+      detectBrowsers.getAvailableBrowsers()
       .then(browsers => {
         resolve(browsers.map(
           browser => {
             return {
-              name: browser.name,
-              code: browser.name.toLowerCase(),
-              launchCmd: browser.executablePath,
+              name: browser.browser,
+              code: browser.browser.toLowerCase(),
+              launchCmd: browser.path,
               versionCode: '',
               versionName: ''
             };


### PR DESCRIPTION
Somehow Firefox is not detected on my Windows10. It is resolved by bumping `detect-browsers` into the latest.

Side effect is some browser codes are changed

Before

```
Browsers on device: PC (serial: )
-----------------------------------------------------
chrome
chromecanary
internet explorer
microsoft edge
-----------------------------------------------------
```

After

```
Browsers on device: PC (serial: )
-----------------------------------------------------
firefox nightly
google chrome canary
google chrome
internet explorer
microsoft edge
-----------------------------------------------------
```
