### PR TITLE
Explicitly set content type for webgfx-tests.js

### DIFF
--- a/src/main/server/http_server.js
+++ b/src/main/server/http_server.js
@@ -48,6 +48,7 @@ function initServer(port, config, verbose) {
   server
     .get('/webgfx-tests.js', (req, res) => {
       var html = fs.readFileSync(__dirname + baseFolder + 'dist/webgfx-tests.js', 'utf8');
+      res.set('Content-Type', 'application/javascript');
       res.send(html);
     })
     .post('/store_test_start', (req, res) => {


### PR DESCRIPTION
Explicitly set "Content-type" for `webgfx-tests.js` to suppress the following warning in Firefox

```
The script from “http://10.0.0.60:3000/webgfx-tests.js” was
loaded even though its MIME type (“text/html”) is not a valid JavaScript MIME type.
```