### PR TITLE
Add canvasId test option

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -98,10 +98,20 @@ window.TESTER = {
       if (typeof parameters['no-rendering'] !== 'undefined') {
         this.ready = true;
       } else {
-        // We assume the last webgl context being initialized is the one used to rendering
-        // If that's different, the test should have a custom code to return that canvas
         if (CanvasHook.getNumContexts() > 0) {
-          var context = CanvasHook.getContext(CanvasHook.getNumContexts() - 1);
+          let context = null;
+          if (typeof parameters['canvas-id'] !== 'undefined') {
+            const contexts = CanvasHook.getContextsByCanvasId( parameters['canvas-id'] );
+            if (contexts.length > 0) {
+              // Use the first context so far
+              context = contexts[0];
+            }
+          }
+          if (context === null) {
+            // We assume the last webgl context being initialized is the one used to rendering
+            // If that's different, the test should have a custom code to return that canvas
+            context = CanvasHook.getContext(CanvasHook.getNumContexts() - 1);
+          }
           this.canvas = context.canvas;
 
           // Prevent events not defined as event-listeners

--- a/src/main/testsmanager/common.js
+++ b/src/main/testsmanager/common.js
@@ -23,9 +23,8 @@ function buildTestURL(baseURL, test, mode, options, progress) {
     if (getOption('numFrames')) url = addGET(url, 'num-frames=' + getOption('numFrames'));
     if (getOption('canvasWidth')) url = addGET(url, 'width=' + getOption('canvasWidth'));
     if (getOption('canvasHeight')) url = addGET(url, 'height=' + getOption('canvasHeight'));
-
+    if (getOption('canvasId')) url = addGET(url, 'canvas-id=' + getOption('canvasId'));
     if (getOption('fakeWebGL')) url = addGET(url, 'fake-webgl');
-
     if (getOption('fakeWebAudio')) url = addGET(url, 'fake-webaudio');
 
     if (mode === 'record') {


### PR DESCRIPTION
Fixes #98 

This PR adds `canvasId` option to test configuration. If `canvasId` is set, `webgfx-tests` finds context whose canvas's id is the id specified with `canvasId`. It helps find the right canvas and context in case where two or more canvas and contexts are created in an app.

This change requires https://github.com/fernandojsg/canvas-hook/pull/1