### PR TITLE
Add customStart test property

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -33,6 +33,7 @@ console.logError = (msg) => console.error(msg);
 window.TESTER = {
   XRready: false,
   ready: false,
+  appReady: false,
   finished: false,
   inputLoading: false,
 
@@ -76,12 +77,18 @@ window.TESTER = {
 
   isReady: function() {
     // console.log(this.ready, this.XRready);
-    return this.ready && this.XRready;
+    return this.ready && this.XRready && this.appReady;
   },
 
   preTick: function() {
     if (GFXTESTS_CONFIG.preMainLoop) {
       GFXTESTS_CONFIG.preMainLoop();
+    }
+
+    if (!this.appReady) {
+      if (typeof parameters['custom-start'] === 'undefined') {
+        this.appReady = true;
+      }
     }
 
     // console.log('ready', this.ready, 'xrready', this.XRready);
@@ -168,7 +175,7 @@ window.TESTER = {
   },
 
   postTick: function () {
-    if (!this.ready || !this.XRready) {return;}
+    if (!this.isReady()) {return;}
 
     if (this.started){
       // console.log('<< frameend');
@@ -820,6 +827,7 @@ window.TESTER = {
           return newPose;
         }
       }
+
       callback(performance.now(), frame);
 
       // If reaching the last RAF, execute all the post code

--- a/src/main/testsmanager/common.js
+++ b/src/main/testsmanager/common.js
@@ -27,6 +27,7 @@ function buildTestURL(baseURL, test, mode, options, progress) {
     if (getOption('fakeWebGL')) url = addGET(url, 'fake-webgl');
 
     if (getOption('fakeWebAudio')) url = addGET(url, 'fake-webaudio');
+    if (getOption('customStart')) url = addGET(url, 'custom-start');
 
     if (mode === 'record') {
       url = addGET(url, 'recording');


### PR DESCRIPTION
From #39.

This PR adds `customStart` test property. If `customStart` is set to `true`, test manager adds `custom-start` to the URL get query.

And this PR adds `appReady` property to `TESTER`. If the URL get query doesn't include `custom-start` then `appReady` will automatically be true. Otherwise, the test application manually needs to set it to true when it's ready to start the test.

```javascript
foo.addEventListener('bar', event => {
    TESTER.appReady = true;
});
```

The test starts measurement once `appReady` and existing `ready` and `XRready` are true.
