### PR TITLE
Add reverse ports tcp:8888

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -490,6 +490,8 @@ program
           if (options.localhost) {
             console.log('Reverse ports tcp:3000 => tcp:3000');
             await device.openPorts(3000, 3000);
+            console.log('Reverse ports tcp:8888 => tcp:8888');
+            await device.openPorts(8888, 8888);
           }
           browsersToRun = browsers;
           if (options.browser && options.browser !== 'all') {


### PR DESCRIPTION
`-h` option does port forwarding for `localhost` from mobile `tcp:3000` to desktop. I think we also need to do `tcp:8888` for websocket.

https://github.com/MozillaReality/webgfx-tests/blob/a82a4d44bb92d11cac87ad382f25452c05101b0f/src/main/server/http_server.js#L93

https://github.com/MozillaReality/webgfx-tests/blob/a82a4d44bb92d11cac87ad382f25452c05101b0f/src/client/index.js#L392

