### PR TITLE
Fix a missing store_test_results access point in http_server

### DIFF
--- a/src/main/server/http_server.js
+++ b/src/main/server/http_server.js
@@ -54,6 +54,10 @@ function initServer(port, config, verbose) {
       console.log('Starting a new test', req.body);
       res.send('');
     })
+    .post('/store_test_results', (req, res) => {
+      console.log('Storing test results', req.body);
+      res.send('');
+    })
     .post('/store_system_info', (req, res) => {
       console.log('Storing system info', req.body);
       res.send('');


### PR DESCRIPTION
This PR fixes a missing `store_test_results` access point in http_server accessed by results-server.

https://github.com/MozillaReality/webgfx-tests/blob/master/src/frontapp/results-server.js#L30