### PR TITLE
Fix a wrong callback parameter to initWebSocketServer

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -201,8 +201,10 @@ program
     } else {
 
       initHTTPServer(options.port, config, options.verbose);
-      initWebSocketServer(options.wsport, (data, io) => {
-        io.emit('test_finished', data);
+      initWebSocketServer(options.wsport, {
+        testFinished: (data, io) => {
+          io.emit('test_finished', data);
+        }
       }, options.verbose);
 
       if (options.launchbrowser) {


### PR DESCRIPTION
This PR fixes a wrong callback parameter to `initWebSocketServer`.