### PR TITLE
Fix a bug checking a wrong reference

### DIFF
--- a/src/main/server/websockets_server.js
+++ b/src/main/server/websockets_server.js
@@ -43,7 +43,7 @@ function initWebSocketServer(port, callbacks, verbose) {
     });
 
     socket.on('test_started', (data) => {
-      if (callbacks && callbacks.testFinished) {
+      if (callbacks && callbacks.testStarted) {
         callbacks.testStarted(data);
       }
       log(`  - Test started: ${chalk.yellow(data.id)}`);


### PR DESCRIPTION
The following line calls `callbacks.testStarted(data);` so the if statement should check the existence of `testStarted`, not `testFinished`.