### PR TITLE
Formatting and fix frontapp

### DIFF
--- a/src/frontapp/index.html
+++ b/src/frontapp/index.html
@@ -61,175 +61,170 @@
           <div style="width: 200px; display: flex">
             Filter: &nbsp;<b-input v-model="filter" size="is-small" width="40"></b-input>
           </div>
-        <b-table
-        :data="filteredTests"
-        :checked-rows.sync="checkedTests"
-        checkable
-        per-page="10"
-        :striped="true"
-        narrowed
-        >
-        <template slot-scope="props">
-          <b-table-column field="id" label="ID" sortable>
-            <span style="white-space: nowrap">{{ props.row.id }}</span>
-          </b-table-column>
-          <b-table-column field="name" label="name" sortable>
-            {{ props.row.name }}
-          </b-table-column>
-          <b-table-column field="engine" label="engine" sortable>
-            {{ props.row.engine }}
-          </b-table-column>
-          <b-table-column field="apis" label="APIs" sortable>
-            {{ props.row.apis &&  props.row.apis.join(', ')}}
-          </b-table-column>
-          <b-table-column label="test">
-            <button class="button is-small" v-on:click="runTest(props.row,false)">test</button>
-          </b-table-column>
-          <b-table-column label="launch">
-            <button class="button is-small" v-on:click="runTest(props.row,true)">launch</button>
-          </b-table-column>
-          <b-table-column label="record">
-            <button class="button is-danger is-small" v-on:click="runTest(props.row, false, true)">record</button>
-          </b-table-column>
-        </template>
-      </b-table>
+          <b-table
+            :data="filteredTests"
+            :checked-rows.sync="checkedTests"
+            checkable
+            per-page="10"
+            :striped="true"
+            narrowed
+          >
+            <b-table-column field="id" label="ID" v-slot="props" sortable>
+              <span style="white-space: nowrap">{{ props.row.id }}</span>
+            </b-table-column>
+            <b-table-column field="name" label="name" v-slot="props" sortable>
+              {{ props.row.name }}
+            </b-table-column>
+            <b-table-column field="engine" label="engine" v-slot="props" sortable>
+              {{ props.row.engine }}
+            </b-table-column>
+            <b-table-column field="apis" label="APIs" v-slot="props" sortable>
+              {{ props.row.apis && props.row.apis.join(', ')}}
+            </b-table-column>
+            <b-table-column label="test" v-slot="props">
+              <button class="button is-small" v-on:click="runTest(props.row,false)">test</button>
+            </b-table-column>
+            <b-table-column label="launch" v-slot="props">
+              <button class="button is-small" v-on:click="runTest(props.row,true)">launch</button>
+            </b-table-column>
+            <b-table-column label="record" v-slot="props">
+              <button class="button is-danger is-small" v-on:click="runTest(props.row, false, true)">record</button>
+            </b-table-column>
+          </b-table>
+          <br>
+          <h2 class="subtitle">Options</h2>
+          <div class="columns">
+            <div class="column is-four-fifths">
+              <b-field horizontal label="Num. times" custom-class="is-small">
+                <input type="text" class="input is-small" style="width: 100px" v-model="options.general.numTimesToRunEachTest">
+              </b-field>
+              <b-field horizontal label="Fake WebGL" custom-class="is-small">
+                <b-checkbox size="is-small" v-model="options.tests.fakeWebGL"></b-checkbox>
+              </b-field>
+              <b-field horizontal label="Fake WebAudio" custom-class="is-small">
+                <b-checkbox size="is-small" v-model="options.tests.fakeWebAudio"></b-checkbox>
+              </b-field>
+              <b-field horizontal label="Keep window open" custom-class="is-small">
+                <b-checkbox size="is-small" v-model="options.tests.noCloseOnFail"></b-checkbox>
+              </b-field>
+              <b-field horizontal label="Show input" custom-class="is-small">
+                <b-field>
+                  <b-checkbox size="is-small" v-model="options.tests.showKeys"> keystrokes</b-checkbox>
+                  <b-checkbox size="is-small" v-model="options.tests.showMouse"> mouse</b-checkbox>
+                </b-field>
+              </b-field>
+            </div>
+            <div class="column">
+              <button class="button is-primary" v-on:click="runSelectedTests()" id='runTests'>Run tests ({{checkedTests.length}} selected)</button>
+            </div>
+          </div>
+          <br>
 
-      <br>
-      <h2 class="subtitle">Options</h2>
-      <div class="columns">
-        <div class="column is-four-fifths">
-          <b-field horizontal label="Num. times" custom-class="is-small">
-            <input type="text" class="input is-small" style="width: 100px" v-model="options.general.numTimesToRunEachTest">
-          </b-field>
-          <b-field horizontal label="Fake WebGL" custom-class="is-small">
-            <b-checkbox size="is-small" v-model="options.tests.fakeWebGL"></b-checkbox>
-          </b-field>
-          <b-field horizontal label="Fake WebAudio" custom-class="is-small">
-            <b-checkbox size="is-small" v-model="options.tests.fakeWebAudio"></b-checkbox>
-          </b-field>
-          <b-field horizontal label="Keep window open" custom-class="is-small">
-            <b-checkbox size="is-small" v-model="options.tests.noCloseOnFail"></b-checkbox>
-          </b-field>
-          <b-field horizontal label="Show input" custom-class="is-small">
-            <b-field>
-              <b-checkbox size="is-small" v-model="options.tests.showKeys"> keystrokes</b-checkbox>
-              <b-checkbox size="is-small" v-model="options.tests.showMouse"> mouse</b-checkbox>
-            </b-field>
-          </b-field>
-        </div>
-        <div class="column">
-          <button class="button is-primary" v-on:click="runSelectedTests()" id='runTests'>Run tests ({{checkedTests.length}} selected)</button>
-        </div>
-      </div>
-      <br>
+          <template>
+            <h2 class="subtitle">Results log</h2>
+            <b-table
+              :data="results"
+              paginated
+              per-page="10"
+              detailed
+              :striped="true"
+              narrowed
+              v-if="results.length > 0"
+            >
+              <b-table-column field="test_id" label="ID" width="40" v-slot="props" sortable>
+                {{ props.row.test_id }}
+              </b-table-column>
+              <b-table-column field="options" label="Options" v-slot="props" sortable>
+                {{ props.row.options }}
+              </b-table-column>
+              <b-table-column field="result" label="Result" v-slot="props" sortable>
+                <span v-if="props.row.result === 'fail'" class="tag is-danger">fail</span>
+                <span v-else class="tag is-success">pass</span>
+              </b-table-column>
+              <b-table-column field="totalTime" label="Total time" v-slot="props" sortable>
+                {{ formatNumeric(props.row.totalTime) }}
+              </b-table-column>
+              <b-table-column field="timeToFirstFrame" label="First frame" v-slot="props" sortable>
+                {{ formatNumeric(props.row.timeToFirstFrame) }}
+              </b-table-column>
+              <b-table-column field="avgFps" label="FPS" v-slot="props" sortable>
+                {{ formatNumeric(props.row.avgFps) }}
+              </b-table-column>
+              <b-table-column field="cpuTime" label="CPU Time" v-slot="props" sortable>
+                {{ formatNumeric(props.row.cpuTime) }}
+              </b-table-column>
+              <b-table-column field="cpuIdlePerc" label="CPU Idle" v-slot="props" sortable>
+                {{ formatNumeric(props.row.cpuIdlePerc) }}
+              </b-table-column>
+              <b-table-column field="numStutterEvents" label="# Janked frames" v-slot="props" sortable>
+                {{ props.row.numStutterEvents }}
+              </b-table-column>
 
-      <template>
-        <h2 class="subtitle">Results log</h2>
-        <b-table
-        :data="results"
-        paginated
-        per-page="10"
-        detailed
-        :striped="true"
-        narrowed
-        v-if="results.length > 0"
-        >
+              <template slot="detail" slot-scope="props">
+                <pre v-html="prettyPrint(JSON.parse(props.row.json))"></pre>
+              </template>
+            </b-table>
 
-        <template slot-scope="props">
-          <b-table-column field="test_id" label="ID" width="40" sortable>
-            {{ props.row.test_id }}
-          </b-table-column>
-          <b-table-column field="options" label="Options" sortable>
-            {{ props.row.options }}
-          </b-table-column>
-          <b-table-column field="result" label="Result" sortable>
-            <span v-if="props.row.result === 'fail'" class="tag is-danger">fail</span>
-            <span v-else class="tag is-success">pass</span>
-          </b-table-column>
-          <b-table-column field="totalTime" label="Total time" sortable>
-            {{ formatNumeric(props.row.totalTime) }}
-          </b-table-column>
-          <b-table-column field="timeToFirstFrame" label="First frame" sortable>
-            {{ formatNumeric(props.row.timeToFirstFrame) }}
-          </b-table-column>
-          <b-table-column field="avgFps" label="FPS" sortable>
-            {{ formatNumeric(props.row.avgFps) }}
-          </b-table-column>
-          <b-table-column field="cpuTime" label="CPU Time" sortable>
-            {{ formatNumeric(props.row.cpuTime) }}
-          </b-table-column>
-          <b-table-column field="cpuIdlePerc" label="CPU Idle" sortable>
-            {{ formatNumeric(props.row.cpuIdlePerc) }}
-          </b-table-column>
-          <b-table-column field="numStutterEvents" label="# Janked frames" sortable>
-            {{ props.row.numStutterEvents }}
-          </b-table-column>
-        </template>
-        
-        <template slot="detail" slot-scope="props">
-          <pre v-html="prettyPrint(JSON.parse(props.row.json))"></pre>
-        </template>
-      </b-table>
-      
-      <div v-if="resultsAverage.length > 0">
-        <h2 class="subtitle">Results average by test ID</h2>
-        <b-table :data="resultsAverage">
-          <template slot-scope="props">
-            <b-table-column field="test_id" label="ID" width="40" sortable>
-              <b>{{ props.row.test_id }}</b>
-            </b-table-column>
-            <b-table-column field="numSamples" label="# Samples" width="40" sortable>
-              {{ props.row.numSamples }}
-            </b-table-column>
-            <b-table-column field="totalTime" label="Total Time" width="40" sortable>
-              {{ formatNumeric(props.row.totalTime) }}
-            </b-table-column>
-            <b-table-column field="cpuIdlePerc" label="CPU Idle %" width="40" sortable>
-              {{ formatNumeric(props.row.cpuIdlePerc) }}
-            </b-table-column>
-            <b-table-column field="cpuIdleTime" label="CPU Idle time" width="40" sortable>
-              {{ formatNumeric(props.row.cpuIdleTime) }}
-            </b-table-column>
-            <b-table-column field="cpuTime" label="CPU Time" width="40" sortable>
-              {{ formatNumeric(props.row.cpuTime) }}
-            </b-table-column>
-            <b-table-column field="pageLoadTime" label="Page load time" width="40" sortable>
-              {{ formatNumeric(props.row.pageLoadTime) }}
-            </b-table-column>
-            <b-table-column field="avgFps" label="Avg. FPS" width="40" sortable>
-              {{ formatNumeric(props.row.avgFps) }}
-            </b-table-column>
-            <b-table-column field="timeToFirstFrame" label="Time to first frame" width="40" sortable>
-              {{ formatNumeric(props.row.timeToFirstFrame) }}
-            </b-table-column>
-            <b-table-column field="numStutterEvents" label="# Janked frames" width="40" sortable>
-              {{ formatNumeric(props.row.numStutterEvents) }}
-            </b-table-column>
+            <div v-if="resultsAverage.length > 0">
+              <h2 class="subtitle">Results average by test ID</h2>
+              <b-table :data="resultsAverage">
+                <b-table-column field="test_id" label="ID" width="40" v-slot="props" sortable>
+                  <b>{{ props.row.test_id }}</b>
+                </b-table-column>
+                <b-table-column field="numSamples" label="# Samples" width="40" v-slot="props" sortable>
+                  {{ props.row.numSamples }}
+                </b-table-column>
+                <b-table-column field="totalTime" label="Total Time" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.totalTime) }}
+                </b-table-column>
+                <b-table-column field="cpuIdlePerc" label="CPU Idle %" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.cpuIdlePerc) }}
+                </b-table-column>
+                <b-table-column field="cpuIdleTime" label="CPU Idle time" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.cpuIdleTime) }}
+                </b-table-column>
+                <b-table-column field="cpuTime" label="CPU Time" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.cpuTime) }}
+                </b-table-column>
+                <b-table-column field="pageLoadTime" label="Page load time" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.pageLoadTime) }}
+                </b-table-column>
+                <b-table-column field="avgFps" label="Avg. FPS" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.avgFps) }}
+                </b-table-column>
+                <b-table-column field="timeToFirstFrame" label="Time to first frame" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.timeToFirstFrame) }}
+                </b-table-column>
+                <b-table-column field="numStutterEvents" label="# Janked frames" width="40" v-slot="props" sortable>
+                  {{ formatNumeric(props.row.numStutterEvents) }}
+                </b-table-column>
+              </b-table>
+            </div>
           </template>
-        </b-table>    
-      </div>
-    </template>
-  </b-tab-item>
-  <b-tab-item label="System info">
-    <h1 class="title">Browser environmnet</h1>
-    <h2 class="subtitle">Common features</h2>
-    <pre v-html="prettyPrint(getBrowserInfo())"></pre>
-    <hr>
-    <h2 class="subtitle">WebGL Support</h2>
-    <pre v-html="prettyPrint(webglInfo)"></pre>
-  </b-tab-item>
-</b-tabs>
+        </b-tab-item>
+        <b-tab-item label="System info">
+          <h1 class="title">Browser environmnet</h1>
+          <h2 class="subtitle">Common features</h2>
+          <pre v-html="prettyPrint(getBrowserInfo())"></pre>
+          <hr>
+          <h2 class="subtitle">WebGL Support</h2>
+          <pre v-html="prettyPrint(webglInfo)"></pre>
+        </b-tab-item>
+      </b-tabs>
 <!--
-  <footer class="footer">
-    <div class="content has-text-centered">
-      <p>
-        <strong>webgfx-tests</strong> by <a href="https://mixedreality.mozilla.org/">Mozilla Mixed Reality team</a>. The source code is available on <a href="https://github.com/MozillaReality/webgfx-tests">github.
-        </p>
-      </div>
-    </footer>-->
+      <footer class="footer">
+        <div class="content has-text-centered">
+          <p>
+            <strong>webgfx-tests</strong> by <a href="https://mixedreality.mozilla.org/">Mozilla Mixed Reality team</a>. The source code is available on <a href="https://github.com/MozillaReality/webgfx-tests">github.
+          </p>
+        </div>
+      </footer>
+-->
+    </div>
   </div>
-</div>
-<!--<script src="index.js" async defer></script>-->
-<script src="app.bundle.js" async defer></script>
+<!--
+  <script src="index.js" async defer></script>
+-->
+  <script src="app.bundle.js" async defer></script>
 </body>
 </html>


### PR DESCRIPTION
This PR resolves #111

```
<b-table :data="myData">
    <template slot-scope="props">
        <b-table-column field="name" label="Name">
            {{ props.row.name }}
        </b-table-column>
        <b-table-column field="age" numeric label="Age">
            {{ props.row.age }}
        </b-table-column>
    </template>
</b-table>
```

should be

```
<b-table :data="myData">
    <b-table-column field="name" label="Name" v-slot="props">
        {{ props.row.name }}
    </b-table-column>
    <b-table-column field="age" label="Age">
        <template v-slot:default="props">
            {{ props.row.age }}
        </template>
    </b-table-column>
</b-table>
```

in buefy v0.9.0 or newer.

https://github.com/buefy/buefy/releases/tag/v0.9.0