### PR TITLE
Add noCanvasResize test parameter

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1069,21 +1069,23 @@ window.TESTER = {
   onResize: function (e) {
     if (e && e.origin === 'webgfxtest') return;
 
-    const DEFAULT_WIDTH = 800;
-    const DEFAULT_HEIGHT = 600;
-    this.canvasWidth = DEFAULT_WIDTH;
-    this.canvasHeight = DEFAULT_HEIGHT;
+    if (typeof parameters['no-canvas-resize'] === 'undefined') {
+      const DEFAULT_WIDTH = 800;
+      const DEFAULT_HEIGHT = 600;
+      this.canvasWidth = DEFAULT_WIDTH;
+      this.canvasHeight = DEFAULT_HEIGHT;
 
-    if (typeof parameters['keep-window-size'] === 'undefined') {
-      this.canvasWidth = typeof parameters['width'] === 'undefined' ? DEFAULT_WIDTH : parseInt(parameters['width']);
-      this.canvasHeight = typeof parameters['height'] === 'undefined' ? DEFAULT_HEIGHT : parseInt(parameters['height']);
-      window.innerWidth = this.canvasWidth;
-      window.innerHeight = this.canvasHeight;
-    }
+      if (typeof parameters['keep-window-size'] === 'undefined') {
+        this.canvasWidth = typeof parameters['width'] === 'undefined' ? DEFAULT_WIDTH : parseInt(parameters['width']);
+        this.canvasHeight = typeof parameters['height'] === 'undefined' ? DEFAULT_HEIGHT : parseInt(parameters['height']);
+        window.innerWidth = this.canvasWidth;
+        window.innerHeight = this.canvasHeight;
+      }
 
-    if (this.canvas) {
-      this.canvas.width = this.canvasWidth;
-      this.canvas.height = this.canvasHeight;
+      if (this.canvas) {
+        this.canvas.width = this.canvasWidth;
+        this.canvas.height = this.canvasHeight;
+      }
     }
 
     var e = document.createEventObject ? document.createEventObject() : document.createEvent("Events");

--- a/src/main/testsmanager/common.js
+++ b/src/main/testsmanager/common.js
@@ -27,6 +27,7 @@ function buildTestURL(baseURL, test, mode, options, progress) {
     if (getOption('fakeWebGL')) url = addGET(url, 'fake-webgl');
 
     if (getOption('fakeWebAudio')) url = addGET(url, 'fake-webaudio');
+    if (getOption('noCanvasResize')) url = addGET(url, 'no-canvas-resize');
 
     if (mode === 'record') {
       url = addGET(url, 'recording');


### PR DESCRIPTION
Resolves #119.

This PR adds `noCanvasResize` test parameter which prevents the canvas resize.